### PR TITLE
Enable custom log labels per log

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ const options = {
 };
 const logger = createLogger(options);
 ```
+
+You can set custom labels in every log as well like this:
+```js
+logger.debug({ message: 'test', labels: { 'key': 'value' } })
+```
+
 TODO: Add custom formatting example
 
 ## Developing

--- a/index.js
+++ b/index.js
@@ -48,18 +48,23 @@ class LokiTransport extends Transport {
     })
 
     // Deconstruct the log
-    const { label, timestamp, level, message, ...rest } = info
+    const { label, labels, timestamp, level, message, ...rest } = info
 
     // build custom labels if provided
-    let labels
+    let lokiLabels
     if (this.labels) {
-      labels = `{level="${level}"`
+      lokiLabels = `{level="${level}"`
       for (let key in this.labels) {
-        labels += `,${key}="${this.labels[key]}"`
+        lokiLabels += `,${key}="${this.labels[key]}"`
       }
-      labels += '}'
+      if (labels) {
+        for (let key in labels) {
+          lokiLabels += `,${key}="${labels[key]}"`
+        }
+      }
+      lokiLabels += '}'
     } else {
-      labels = `{job="${label}", level="${level}"}`
+      lokiLabels = `{job="${label}", level="${level}"}`
     }
 
     // follow the format provided
@@ -69,7 +74,7 @@ class LokiTransport extends Transport {
 
     // Construct the log to fit Grafana Loki's accepted format
     const logEntry = {
-      labels: labels,
+      labels: lokiLabels,
       entries: [
         {
           ts: timestamp || Date.now(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/custom-labels-lines.test.js
+++ b/test/custom-labels-lines.test.js
@@ -45,13 +45,14 @@ describe('Integration tests', function () {
     const logger = createLogger(options)
 
     const testMessage = 'testMessage'
+    const testLabel = 'testLabel'
     const now = Date.now() / 1000
-    logger.debug(testMessage)
+    logger.debug({ message: testMessage, labels: { 'customLabel': testLabel } })
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(
       lokiTransport.batcher.batch.streams[0]
     ).toEqual({
-      labels: '{level="debug",module="name",app="appname"}',
+      labels: `{level="debug",module="name",app="appname",customLabel="${testLabel}"}`,
       entries: [{
         line: `[name] ${testMessage}`,
         timestamp: {


### PR DESCRIPTION
This adds the functionality to set whichever log label you want to set whenever you log something.
My use-case is:
I have a queuing system which resolves various types of tasks.
I wanted to display all logs for a specific type of task in grafana. Using this I can set the label "taskType" to whatever I need it to be from inside the tasks, where the log statements are.