### PR TITLE
Prepare for 6.0.0 release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 test
+examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "10"
+  - "12"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # winston-loki
 
 [![npm version](https://badge.fury.io/js/winston-loki.svg)](https://badge.fury.io/js/winston-loki)
+[![install size](https://packagephobia.now.sh/badge?p=winston-loki)](https://packagephobia.now.sh/result?p=winston-loki)
 [![Build Status](https://travis-ci.com/JaniAnttonen/winston-loki.svg?branch=master)](https://travis-ci.com/JaniAnttonen/winston-loki)
 [![Coverage Status](https://coveralls.io/repos/github/JaniAnttonen/winston-loki/badge.svg?branch=master)](https://coveralls.io/github/JaniAnttonen/winston-loki?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/17a55cce14d581c308bc/maintainability)](https://codeclimate.com/github/JaniAnttonen/winston-loki/maintainability)
-[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 
 A Grafana Loki transport for the nodejs logging library Winston.

--- a/examples/basicAuth.js
+++ b/examples/basicAuth.js
@@ -1,0 +1,30 @@
+const winston = require('winston')
+const LokiTransport = require('../index')
+const logger = winston.createLogger()
+
+logger.add(new winston.transports.Console({
+  format: winston.format.json(),
+  level: 'debug'
+}))
+
+logger.add(new LokiTransport({
+  host: 'http://127.0.0.1:3100',
+  json: true,
+  basicAuth: 'username:password',
+  labels: { job: 'winston-loki-example' }
+}))
+
+const wait = (duration) => new Promise(resolve => {
+  setTimeout(resolve, duration)
+})
+
+const run = async () => {
+  while (true) {
+    logger.debug('I am a debug log')
+    logger.info('This is a test, no need to panic')
+    logger.error('Testing for errors')
+    await wait(1000)
+  }
+}
+
+run()

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: "3"
+
+networks:
+  loki:
+
+services:
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - loki
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - /var/log:/var/log
+    command: -config.file=/etc/promtail/docker-config.yaml
+    networks:
+      - loki
+
+  grafana:
+    image: grafana/grafana:master
+    ports:
+      - "3000:3000"
+    networks:
+      - loki

--- a/examples/index.js
+++ b/examples/index.js
@@ -12,7 +12,7 @@ logger.add(new LokiTransport({
   json: true,
   batching: true,
   interval: 15,
-  labels: { job: 'winston-loki-example' },
+  labels: { job: 'winston-loki-example' }
 }))
 
 const wait = (duration) => new Promise(resolve => {
@@ -29,4 +29,3 @@ const run = async () => {
 }
 
 run()
-

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,0 +1,15 @@
+const winston = require('winston');
+const LokiTransport = require('../index');
+const logger = winston.createLogger();
+
+logger.add(new winston.transports.Console({
+     format: winston.format.json(),
+     level: 'debug'
+}));
+
+logger.add(new LokiTransport({
+     host: "http://127.0.0.1:3100"
+}));
+
+logger.info('This is a test, no need to panic')
+logger.error('Testing for errors')

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,15 +1,32 @@
-const winston = require('winston');
-const LokiTransport = require('../index');
-const logger = winston.createLogger();
+const winston = require('winston')
+const LokiTransport = require('../index')
+const logger = winston.createLogger()
 
 logger.add(new winston.transports.Console({
-     format: winston.format.json(),
-     level: 'debug'
-}));
+  format: winston.format.json(),
+  level: 'debug'
+}))
 
 logger.add(new LokiTransport({
-     host: "http://127.0.0.1:3100"
-}));
+  host: 'http://127.0.0.1:3100',
+  json: true,
+  batching: true,
+  interval: 15,
+  labels: { job: 'winston-loki-example' },
+}))
 
-logger.info('This is a test, no need to panic')
-logger.error('Testing for errors')
+const wait = (duration) => new Promise(resolve => {
+  setTimeout(resolve, duration)
+})
+
+const run = async () => {
+  while (true) {
+    logger.debug('I am a debug log')
+    logger.info('This is a test, no need to panic')
+    logger.error('Testing for errors')
+    await wait(1000)
+  }
+}
+
+run()
+

--- a/examples/index.js
+++ b/examples/index.js
@@ -8,11 +8,10 @@ logger.add(new winston.transports.Console({
 }))
 
 logger.add(new LokiTransport({
-  host: 'http://127.0.0.1:3100',
+  host: 'http://0.0.0.0:3100',
   json: true,
   batching: true,
-  interval: 15,
-  label: 'winston-loki-example'
+  labels: { job: 'winston-loki-example' }
 }))
 
 const wait = (duration) => new Promise(resolve => {

--- a/examples/index.js
+++ b/examples/index.js
@@ -12,7 +12,7 @@ logger.add(new LokiTransport({
   json: true,
   batching: true,
   interval: 15,
-  labels: { job: 'winston-loki-example' }
+  label: 'winston-loki-example'
 }))
 
 const wait = (duration) => new Promise(resolve => {

--- a/examples/index.js
+++ b/examples/index.js
@@ -8,8 +8,8 @@ logger.add(new winston.transports.Console({
 }))
 
 logger.add(new LokiTransport({
-  host: 'http://0.0.0.0:3100',
-  json: true,
+  host: 'http://127.0.0.1:3100',
+  json: false,
   batching: true,
   labels: { job: 'winston-loki-example' }
 }))

--- a/examples/json.js
+++ b/examples/json.js
@@ -1,0 +1,29 @@
+const winston = require('winston')
+const LokiTransport = require('../index')
+const logger = winston.createLogger()
+
+logger.add(new winston.transports.Console({
+  format: winston.format.json(),
+  level: 'debug'
+}))
+
+logger.add(new LokiTransport({
+  host: 'http://127.0.0.1:3100',
+  json: true,
+  labels: { job: 'winston-loki-example' }
+}))
+
+const wait = (duration) => new Promise(resolve => {
+  setTimeout(resolve, duration)
+})
+
+const run = async () => {
+  while (true) {
+    logger.debug('I am a debug log')
+    logger.info('This is a test, no need to panic')
+    logger.error('Testing for errors')
+    await wait(1000)
+  }
+}
+
+run()

--- a/examples/proto.js
+++ b/examples/proto.js
@@ -9,8 +9,6 @@ logger.add(new winston.transports.Console({
 
 logger.add(new LokiTransport({
   host: 'http://127.0.0.1:3100',
-  json: false,
-  batching: true,
   labels: { job: 'winston-loki-example' }
 }))
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class LokiTransport extends Transport {
     // Pass all the given options to batcher
     this.batcher = new Batcher({
       host: options.host,
+      headers: options.headers,
       interval: options.interval,
       json: options.json,
       batching: options.batching !== undefined ? options.batching : true,

--- a/index.js
+++ b/index.js
@@ -56,11 +56,11 @@ class LokiTransport extends Transport {
     let lokiLabels
     if (this.labels) {
       lokiLabels = `{level="${level}"`
-      for (let key in this.labels) {
+      for (const key in this.labels) {
         lokiLabels += `,${key}="${this.labels[key]}"`
       }
       if (labels) {
-        for (let key in labels) {
+        for (const key in labels) {
           lokiLabels += `,${key}="${labels[key]}"`
         }
       }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ class LokiTransport extends Transport {
     // Pass all the given options to batcher
     this.batcher = new Batcher({
       host: options.host,
-      headers: options.headers,
+      basicAuth: options.basicAuth,
+      headers: options.headers || {},
       interval: options.interval,
       json: options.json,
       batching: options.batching !== false,

--- a/index.js
+++ b/index.js
@@ -68,10 +68,10 @@ class LokiTransport extends Transport {
 
     // Construct the log to fit Grafana Loki's accepted format
     const logEntry = {
-      stream: lokiLabels,
+      labels: lokiLabels,
       entries: [
         {
-          ts: timestamp || Date.now(),
+          ts: timestamp || Date.now().valueOf(),
           line
         }
       ]

--- a/index.js
+++ b/index.js
@@ -53,20 +53,12 @@ class LokiTransport extends Transport {
     const { label, labels, timestamp, level, message, ...rest } = info
 
     // build custom labels if provided
-    let lokiLabels
+    let lokiLabels = { level: level }
+
     if (this.labels) {
-      lokiLabels = `{level="${level}"`
-      for (const key in this.labels) {
-        lokiLabels += `,${key}="${this.labels[key]}"`
-      }
-      if (labels) {
-        for (const key in labels) {
-          lokiLabels += `,${key}="${labels[key]}"`
-        }
-      }
-      lokiLabels += '}'
+      lokiLabels = Object.assign(lokiLabels, this.labels)
     } else {
-      lokiLabels = `{job="${label}", level="${level}"}`
+      lokiLabels['job'] = label
     }
 
     // follow the format provided
@@ -76,7 +68,7 @@ class LokiTransport extends Transport {
 
     // Construct the log to fit Grafana Loki's accepted format
     const logEntry = {
-      labels: lokiLabels,
+      stream: lokiLabels,
       entries: [
         {
           ts: timestamp || Date.now(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,6 +1057,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1557,6 +1557,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
+      "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
     },
     "debug": {
       "version": "3.1.0",
@@ -4754,11 +4759,6 @@
         "mkdirp": "0.5.1",
         "supports-color": "4.4.0"
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,9 +528,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-globals": {
@@ -4487,9 +4487,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -4513,18 +4513,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,30 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/core": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
-      "integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
-        "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helpers": "^7.8.4",
+        "@babel/parser": "^7.8.4",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
@@ -35,21 +36,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -59,12 +45,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-      "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4",
+        "@babel/types": "^7.8.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -79,55 +65,55 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
       "dev": true
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helpers": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-      "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -136,69 +122,52 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-      "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
-      "integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/template": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/traverse": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
-        "@babel/helper-function-name": "^7.7.4",
-        "@babel/helper-split-export-declaration": "^7.7.4",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.8.4",
+        "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "@babel/types": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -455,19 +424,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
-    "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
-    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -482,9 +438,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
-      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -516,9 +472,9 @@
       "dev": true
     },
     "@types/istanbul-lib-report": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
@@ -535,14 +491,14 @@
       }
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "10.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
+      "version": "10.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+      "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -551,18 +507,18 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
-      "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
     "abab": {
@@ -572,9 +528,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
       "dev": true
     },
     "acorn-globals": {
@@ -600,12 +556,12 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -697,13 +653,14 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
       }
     },
     "array-unique": {
@@ -711,6 +668,16 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -778,9 +745,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
     "babel-code-frame": {
@@ -874,9 +841,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -1007,9 +974,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "optional": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -1081,12 +1048,6 @@
         }
       }
     },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -1117,35 +1078,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      }
-    },
-    "cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-        }
       }
     },
     "caller-path": {
@@ -1201,23 +1133,6 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "chardet": {
@@ -1327,29 +1242,11 @@
         }
       }
     },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "cobertura-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cobertura-parse/-/cobertura-parse-1.0.5.tgz",
-      "integrity": "sha512-uYJfkGhzw1wibe/8jqqHmSaPNWFguzq/IlSj83u3cSnZho/lUnfj0mLTmZGmB3AiKCOTYr22TYwpR1sXy2JEkg==",
-      "dev": true,
-      "requires": {
-        "mocha": "5.0.5",
-        "xml2js": "0.4.19"
-      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1433,12 +1330,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -1484,12 +1375,11 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.8.tgz",
-      "integrity": "sha512-lkQlg29RhV9zwB0gDaEAWoap8xPgFxtPsVIpTNiDDtWNrvtP1/RmGJRRAV/Loz2gihmppObkSL0wnptEGUXaOQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
+      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
       "dev": true,
       "requires": {
-        "cobertura-parse": "^1.0.5",
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
@@ -1558,18 +1448,13 @@
         }
       }
     },
-    "date-fns": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
-      "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
-    },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "debug-log": {
@@ -1591,11 +1476,12 @@
       "dev": true
     },
     "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "optional": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^2.0.0"
       }
     },
     "deep-extend": {
@@ -1609,11 +1495,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "defer-to-connect": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.0.tgz",
-      "integrity": "sha512-WE2sZoctWm/v4smfCAdjYbrfS55JiMRdlY9ZubFhsYbteCK9+BvAx4YV7nPjYM6ZnX5BcoVKwfmyx9sIFTgQMQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1722,12 +1603,6 @@
         "kuler": "1.0.x"
       }
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
@@ -1751,11 +1626,6 @@
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -1791,9 +1661,9 @@
       }
     },
     "env-variable": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg==",
       "dev": true
     },
     "error-ex": {
@@ -1806,21 +1676,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -1841,24 +1712,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
       }
     },
     "eslint": {
@@ -1911,21 +1774,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1959,13 +1807,13 @@
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+      "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "resolve": "^1.13.1"
       },
       "dependencies": {
         "debug": {
@@ -1976,16 +1824,22 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+      "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
@@ -1997,6 +1851,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2011,22 +1871,23 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
+      "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
+        "array.prototype.flat": "^1.2.1",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.0",
+        "eslint-module-utils": "^2.4.1",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
         "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "debug": {
@@ -2047,6 +1908,12 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2073,9 +1940,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
-      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -2257,6 +2124,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2390,9 +2263,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-diff": {
@@ -2402,9 +2275,9 @@
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2420,12 +2293,12 @@
       "dev": true
     },
     "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.1.1"
       }
     },
     "fecha": {
@@ -2558,14 +2431,15 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -2613,7 +2487,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2643,7 +2517,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2670,12 +2544,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -2701,7 +2575,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2730,7 +2604,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2749,7 +2623,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2791,7 +2665,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2801,12 +2675,12 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -2819,24 +2693,24 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2850,7 +2724,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -2864,13 +2738,22 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2941,7 +2824,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2982,7 +2865,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3009,7 +2892,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3062,18 +2945,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -3098,7 +2981,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3133,6 +3016,12 @@
         "wide-align": "^1.1.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3149,6 +3038,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -3175,9 +3065,9 @@
       "optional": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -3194,34 +3084,10 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
-    "got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "growly": {
@@ -3229,18 +3095,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3277,9 +3131,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
@@ -3326,12 +3180,6 @@
         }
       }
     },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
@@ -3347,10 +3195,11 @@
         "whatwg-encoding": "^1.0.1"
       }
     },
-    "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -3418,9 +3267,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3594,9 +3443,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-ci": {
@@ -3629,9 +3478,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-descriptor": {
@@ -3710,12 +3559,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-resolvable": {
@@ -3728,6 +3577,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-symbol": {
@@ -3820,12 +3675,6 @@
         "supports-color": "^6.1.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -3848,32 +3697,15 @@
         "make-dir": "^2.1.0",
         "rimraf": "^2.6.3",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "jest": {
@@ -4195,22 +4027,6 @@
         "slash": "^2.0.0",
         "strip-bom": "^3.0.0",
         "yargs": "^13.3.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "jest-serializer": {
@@ -4307,12 +4123,6 @@
         "supports-color": "^6.1.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -4394,11 +4204,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4460,18 +4265,10 @@
         "object.assign": "^4.1.0"
       }
     },
-    "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
@@ -4568,14 +4365,6 @@
         "fecha": "^2.3.3",
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "long": {
@@ -4591,11 +4380,6 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -4667,18 +4451,18 @@
       }
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -4688,9 +4472,10 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+      "optional": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4742,28 +4527,10 @@
         }
       }
     },
-    "mocha": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
-      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      }
-    },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
@@ -4809,12 +4576,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -4822,9 +4583,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.12.0.tgz",
-      "integrity": "sha512-VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.14.0.tgz",
+      "integrity": "sha512-y54KGgEOHnRHlGQi7E5UiryRkH8bmksmQLj/9iLAjoje743YS+KaKB/sDYXgqtT0J16JT3c3AYJZNI98aU/kYg==",
       "optional": true,
       "requires": {
         "semver": "^5.4.1"
@@ -4881,11 +4642,6 @@
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
-    },
-    "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -4996,13 +4752,13 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -5015,13 +4771,13 @@
       }
     },
     "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
@@ -5049,24 +4805,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -5086,11 +4824,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
     "p-each-series": {
       "version": "1.0.0",
@@ -5334,11 +5067,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -5421,9 +5149,9 @@
       }
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
       "dev": true
     },
     "pump": {
@@ -5487,9 +5215,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5622,9 +5350,9 @@
       }
     },
     "resolve": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
-      "integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -5659,14 +5387,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -5690,22 +5410,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "rsvp": {
@@ -5730,9 +5434,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -5855,23 +5559,6 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      },
-      "dependencies": {
-        "decompress-response": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-          "optional": true,
-          "requires": {
-            "mimic-response": "^2.0.0"
-          }
-        },
-        "mimic-response": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
-          "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
-          "optional": true
-        }
       }
     },
     "simple-swizzle": {
@@ -5964,6 +5651,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -6062,12 +5755,12 @@
       "dev": true
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -6195,6 +5888,15 @@
           "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
           "dev": true
         },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -6286,6 +5988,12 @@
                 "esutils": "^2.0.2",
                 "isarray": "^1.0.0"
               }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         },
@@ -6520,9 +6228,9 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -6530,9 +6238,9 @@
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -6573,12 +6281,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "symbol-observable": {
@@ -6665,9 +6373,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "optional": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -6698,20 +6406,6 @@
             "locate-path": "^3.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -6735,9 +6429,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6871,11 +6565,6 @@
         }
       }
     },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -6959,26 +6648,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "uglify-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
-      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -7052,14 +6721,6 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "requires": {
-        "prepend-http": "^2.0.0"
-      }
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -7072,19 +6733,21 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -7206,9 +6869,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7231,12 +6894,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {
@@ -7324,22 +6981,6 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -7402,9 +7043,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4191,9 +4191,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "5.1.2",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "dependencies": {
     "async-exit-hook": "2.0.1",
+    "date-fns": "^2.9.0",
     "got": "^9.5.0",
-    "moment": "^2.24.0",
     "protobufjs": "^6.8.8",
     "winston-transport": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
   },
   "dependencies": {
     "async-exit-hook": "2.0.1",
-    "date-fns": "^2.9.0",
-    "got": "^9.5.0",
     "protobufjs": "^6.8.8",
     "winston-transport": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A Winston transport for Grafana Loki",
   "keywords": [
     "winston",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "async-exit-hook": "2.0.1",
+    "btoa": "^1.2.1",
     "protobufjs": "^6.8.8",
     "winston-transport": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "6.0.0",
+  "version": "6.0.0-rc.1",
   "description": "A Winston transport for Grafana Loki",
   "keywords": [
     "winston",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "5.1.2",
+  "version": "6.0.0",
   "description": "A Winston transport for Grafana Loki",
   "keywords": [
     "winston",

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -29,6 +29,13 @@ class Batcher {
     // Construct Grafana Loki push API url
     this.url = new url.URL(this.options.host + '/loki/api/v1/push')
 
+    // Parse basic auth parameters if given
+    if (options.basicAuth) {
+      const btoa = require('btoa')
+      const basicAuth = 'Basic: ' + btoa(options.basicAuth)
+      this.options.headers = Object.assign(this.options.headers, { 'Authorization': basicAuth })
+    }
+
     // Define the batching intervals
     this.interval = this.options.interval
       ? Number(this.options.interval) * 1000
@@ -190,7 +197,7 @@ class Batcher {
         }
 
         // Send the data to Grafana Loki
-        req.post(this.url, this.contentType, this.headers, reqBody)
+        req.post(this.url, this.contentType, this.options.headers, reqBody)
           .then(res => {
             // No need to clear the batch if batching is disabled
             logEntry === undefined && this.clearBatch()

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -109,7 +109,7 @@ class Batcher {
 
       // Find if there's already a log with identical labels in the batch
       const match = streams.findIndex(
-        stream => stream.labels === logEntry.labels
+        stream => JSON.stringify(stream.labels) === JSON.stringify(logEntry.labels)
       )
 
       if (match > -1) {
@@ -148,13 +148,15 @@ class Batcher {
 
         // If the data format is JSON, there's no need to construct a buffer
         if (this.options.json) {
+          let preparedJSONBatch
           if (logEntry !== undefined) {
             // If a single logEntry is given, wrap it according to the batch format
-            reqBody = JSON.stringify({ streams: [logEntry] })
+            preparedJSONBatch = protoHelpers.prepareJSONBatch({ streams: [logEntry] })
           } else {
             // Stringify the JSON ready for transport
-            reqBody = JSON.stringify(this.batch)
+            preparedJSONBatch = protoHelpers.prepareJSONBatch(this.batch)
           }
+          reqBody = JSON.stringify(preparedJSONBatch)
         } else {
           try {
             let batch

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -167,21 +167,24 @@ class Batcher {
               batch = this.batch
             }
 
+            const preparedBatch = protoHelpers.prepareProtoBatch(batch)
+
             // Check if the batch can be encoded in Protobuf and is correct format
-            const err = logproto.PushRequest.verify(batch)
+            const err = logproto.PushRequest.verify(preparedBatch)
 
             // Reject the promise if the batch is not of correct format
             if (err) reject(err)
 
             // Create the PushRequest object
-            const message = logproto.PushRequest.create(batch)
-
+            const message = logproto.PushRequest.create(preparedBatch)
+            console.log(message)
             // Encode the PushRequest object and create the binary buffer
             const buffer = logproto.PushRequest.encode(message).finish()
-
+            console.log(buffer)
             // Compress the buffer with snappy
             reqBody = snappy.compressSync(buffer)
           } catch (err) {
+            console.log(err)
             reject(err)
           }
         }

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -1,9 +1,9 @@
-const got = require('got')
 const url = require('url')
 const exitHook = require('async-exit-hook')
 
 const { logproto } = require('./proto')
 const protoHelpers = require('./proto/helpers')
+const req = require('./requests')
 let snappy = false
 
 /**
@@ -26,7 +26,7 @@ class Batcher {
     this.options = options
 
     // Construct Grafana Loki push API url
-    this.url = new url.URL(this.options.host + '/api/prom/push').toString()
+    this.url = new url.URL(this.options.host + '/api/prom/push')
 
     // Define the batching intervals
     this.interval = this.options.interval
@@ -182,13 +182,7 @@ class Batcher {
         }
 
         // Send the data to Grafana Loki
-        got
-          .post(this.url, {
-            body: reqBody,
-            headers: {
-              'content-type': this.contentType
-            }
-          })
+        req.post(this.url, this.contentType, reqBody)
           .then(res => {
             // No need to clear the batch if batching is disabled
             logEntry === undefined && this.clearBatch()

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -15,6 +15,7 @@ class Batcher {
   loadSnappy () {
     return require('snappy')
   }
+
   /**
    * Creates an instance of Batcher.
    * Starts the batching loop if enabled.

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -26,7 +26,7 @@ class Batcher {
     this.options = options
 
     // Construct Grafana Loki push API url
-    this.url = new url.URL(this.options.host + '/api/prom/push')
+    this.url = new url.URL(this.options.host + '/loki/api/v1/push')
 
     // Define the batching intervals
     this.interval = this.options.interval

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -182,7 +182,7 @@ class Batcher {
         }
 
         // Send the data to Grafana Loki
-        req.post(this.url, this.contentType, reqBody)
+        req.post(this.url, this.contentType, this.headers, reqBody)
           .then(res => {
             // No need to clear the batch if batching is disabled
             logEntry === undefined && this.clearBatch()

--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -12,5 +12,18 @@ module.exports = {
       })
     }
     return logEntry
+  },
+  prepareJSONBatch: batch => {
+    batch.streams = batch.streams.map(logEntry => {
+      logEntry.stream = logEntry.labels
+      logEntry.values = logEntry.entries
+      logEntry.values = logEntry.values.map(entry => {
+        return [JSON.stringify(entry.ts * 1000 * 1000), entry.line]
+      })
+      delete logEntry.entries
+      delete logEntry.labels
+      return logEntry
+    })
+    return batch
   }
 }

--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -1,14 +1,11 @@
-const moment = require('moment')
-
 module.exports = {
   createProtoTimestamps: logEntry => {
     if (logEntry && logEntry.entries && logEntry.entries.length > 0) {
       logEntry.entries = logEntry.entries.map(entry => {
-        const dt = moment(entry.ts).valueOf()
         return {
           timestamp: {
-            seconds: Math.floor(dt / 1000),
-            nanos: (dt % 1000) * 1000
+            seconds: Math.floor(entry.ts / 1000),
+            nanos: (entry.ts % 1000) * 1000
           },
           line: entry.line
         }

--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -25,5 +25,12 @@ module.exports = {
       return logEntry
     })
     return batch
+  },
+  prepareProtoBatch: batch => {
+    batch.streams = batch.streams.map(logEntry => {
+      logEntry.labels = JSON.stringify(logEntry.labels)
+      return logEntry
+    })
+    return batch
   }
 }

--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -28,7 +28,13 @@ module.exports = {
   },
   prepareProtoBatch: batch => {
     batch.streams = batch.streams.map(logEntry => {
-      logEntry.labels = JSON.stringify(logEntry.labels)
+      let protoLabels = `{level="${logEntry.labels.level}"`
+      delete logEntry.labels.level
+      for (let key in logEntry.labels) {
+        protoLabels += `,${key}="${logEntry.labels[key]}"`
+      }
+      protoLabels += '}'
+      logEntry.labels = protoLabels
       return logEntry
     })
     return batch

--- a/src/proto/index.js
+++ b/src/proto/index.js
@@ -1,26 +1,24 @@
-/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
-"use strict";
+/* eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars */
+'use strict'
 
-var $protobuf = require("protobufjs/minimal");
+var $protobuf = require('protobufjs/minimal')
 
 // Common aliases
-var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+var $Reader = $protobuf.Reader; var $Writer = $protobuf.Writer; var $util = $protobuf.util
 
 // Exported root namespace
-var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+var $root = $protobuf.roots['default'] || ($protobuf.roots['default'] = {})
 
-$root.logproto = (function() {
-
-    /**
+$root.logproto = (function () {
+  /**
      * Namespace logproto.
      * @exports logproto
      * @namespace
      */
-    var logproto = {};
+  var logproto = {}
 
-    logproto.Pusher = (function() {
-
-        /**
+  logproto.Pusher = (function () {
+    /**
          * Constructs a new Pusher service.
          * @memberof logproto
          * @classdesc Represents a Pusher
@@ -30,13 +28,13 @@ $root.logproto = (function() {
          * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
          * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
          */
-        function Pusher(rpcImpl, requestDelimited, responseDelimited) {
-            $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
-        }
+    function Pusher (rpcImpl, requestDelimited, responseDelimited) {
+      $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited)
+    }
 
-        (Pusher.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Pusher;
+    (Pusher.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Pusher
 
-        /**
+    /**
          * Creates new Pusher service using the specified rpc implementation.
          * @function create
          * @memberof logproto.Pusher
@@ -46,11 +44,11 @@ $root.logproto = (function() {
          * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
          * @returns {Pusher} RPC service. Useful where requests and/or responses are streamed.
          */
-        Pusher.create = function create(rpcImpl, requestDelimited, responseDelimited) {
-            return new this(rpcImpl, requestDelimited, responseDelimited);
-        };
+    Pusher.create = function create (rpcImpl, requestDelimited, responseDelimited) {
+      return new this(rpcImpl, requestDelimited, responseDelimited)
+    }
 
-        /**
+    /**
          * Callback as used by {@link logproto.Pusher#push}.
          * @memberof logproto.Pusher
          * @typedef PushCallback
@@ -59,7 +57,7 @@ $root.logproto = (function() {
          * @param {logproto.PushResponse} [response] PushResponse
          */
 
-        /**
+    /**
          * Calls Push.
          * @function push
          * @memberof logproto.Pusher
@@ -69,11 +67,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Pusher.prototype.push = function push(request, callback) {
-            return this.rpcCall(push, $root.logproto.PushRequest, $root.logproto.PushResponse, request, callback);
-        }, "name", { value: "Push" });
+    Object.defineProperty(Pusher.prototype.push = function push (request, callback) {
+      return this.rpcCall(push, $root.logproto.PushRequest, $root.logproto.PushResponse, request, callback)
+    }, 'name', { value: 'Push' })
 
-        /**
+    /**
          * Calls Push.
          * @function push
          * @memberof logproto.Pusher
@@ -83,12 +81,11 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        return Pusher;
-    })();
+    return Pusher
+  })()
 
-    logproto.Querier = (function() {
-
-        /**
+  logproto.Querier = (function () {
+    /**
          * Constructs a new Querier service.
          * @memberof logproto
          * @classdesc Represents a Querier
@@ -98,13 +95,13 @@ $root.logproto = (function() {
          * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
          * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
          */
-        function Querier(rpcImpl, requestDelimited, responseDelimited) {
-            $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
-        }
+    function Querier (rpcImpl, requestDelimited, responseDelimited) {
+      $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited)
+    }
 
-        (Querier.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Querier;
+    (Querier.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Querier
 
-        /**
+    /**
          * Creates new Querier service using the specified rpc implementation.
          * @function create
          * @memberof logproto.Querier
@@ -114,11 +111,11 @@ $root.logproto = (function() {
          * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
          * @returns {Querier} RPC service. Useful where requests and/or responses are streamed.
          */
-        Querier.create = function create(rpcImpl, requestDelimited, responseDelimited) {
-            return new this(rpcImpl, requestDelimited, responseDelimited);
-        };
+    Querier.create = function create (rpcImpl, requestDelimited, responseDelimited) {
+      return new this(rpcImpl, requestDelimited, responseDelimited)
+    }
 
-        /**
+    /**
          * Callback as used by {@link logproto.Querier#query}.
          * @memberof logproto.Querier
          * @typedef QueryCallback
@@ -127,7 +124,7 @@ $root.logproto = (function() {
          * @param {logproto.QueryResponse} [response] QueryResponse
          */
 
-        /**
+    /**
          * Calls Query.
          * @function query
          * @memberof logproto.Querier
@@ -137,11 +134,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Querier.prototype.query = function query(request, callback) {
-            return this.rpcCall(query, $root.logproto.QueryRequest, $root.logproto.QueryResponse, request, callback);
-        }, "name", { value: "Query" });
+    Object.defineProperty(Querier.prototype.query = function query (request, callback) {
+      return this.rpcCall(query, $root.logproto.QueryRequest, $root.logproto.QueryResponse, request, callback)
+    }, 'name', { value: 'Query' })
 
-        /**
+    /**
          * Calls Query.
          * @function query
          * @memberof logproto.Querier
@@ -151,7 +148,7 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        /**
+    /**
          * Callback as used by {@link logproto.Querier#label}.
          * @memberof logproto.Querier
          * @typedef LabelCallback
@@ -160,7 +157,7 @@ $root.logproto = (function() {
          * @param {logproto.LabelResponse} [response] LabelResponse
          */
 
-        /**
+    /**
          * Calls Label.
          * @function label
          * @memberof logproto.Querier
@@ -170,11 +167,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Querier.prototype.label = function label(request, callback) {
-            return this.rpcCall(label, $root.logproto.LabelRequest, $root.logproto.LabelResponse, request, callback);
-        }, "name", { value: "Label" });
+    Object.defineProperty(Querier.prototype.label = function label (request, callback) {
+      return this.rpcCall(label, $root.logproto.LabelRequest, $root.logproto.LabelResponse, request, callback)
+    }, 'name', { value: 'Label' })
 
-        /**
+    /**
          * Calls Label.
          * @function label
          * @memberof logproto.Querier
@@ -184,7 +181,7 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        /**
+    /**
          * Callback as used by {@link logproto.Querier#tail}.
          * @memberof logproto.Querier
          * @typedef TailCallback
@@ -193,7 +190,7 @@ $root.logproto = (function() {
          * @param {logproto.TailResponse} [response] TailResponse
          */
 
-        /**
+    /**
          * Calls Tail.
          * @function tail
          * @memberof logproto.Querier
@@ -203,11 +200,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Querier.prototype.tail = function tail(request, callback) {
-            return this.rpcCall(tail, $root.logproto.TailRequest, $root.logproto.TailResponse, request, callback);
-        }, "name", { value: "Tail" });
+    Object.defineProperty(Querier.prototype.tail = function tail (request, callback) {
+      return this.rpcCall(tail, $root.logproto.TailRequest, $root.logproto.TailResponse, request, callback)
+    }, 'name', { value: 'Tail' })
 
-        /**
+    /**
          * Calls Tail.
          * @function tail
          * @memberof logproto.Querier
@@ -217,7 +214,7 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        /**
+    /**
          * Callback as used by {@link logproto.Querier#series}.
          * @memberof logproto.Querier
          * @typedef SeriesCallback
@@ -226,7 +223,7 @@ $root.logproto = (function() {
          * @param {logproto.SeriesResponse} [response] SeriesResponse
          */
 
-        /**
+    /**
          * Calls Series.
          * @function series
          * @memberof logproto.Querier
@@ -236,11 +233,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Querier.prototype.series = function series(request, callback) {
-            return this.rpcCall(series, $root.logproto.SeriesRequest, $root.logproto.SeriesResponse, request, callback);
-        }, "name", { value: "Series" });
+    Object.defineProperty(Querier.prototype.series = function series (request, callback) {
+      return this.rpcCall(series, $root.logproto.SeriesRequest, $root.logproto.SeriesResponse, request, callback)
+    }, 'name', { value: 'Series' })
 
-        /**
+    /**
          * Calls Series.
          * @function series
          * @memberof logproto.Querier
@@ -250,7 +247,7 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        /**
+    /**
          * Callback as used by {@link logproto.Querier#tailersCount}.
          * @memberof logproto.Querier
          * @typedef TailersCountCallback
@@ -259,7 +256,7 @@ $root.logproto = (function() {
          * @param {logproto.TailersCountResponse} [response] TailersCountResponse
          */
 
-        /**
+    /**
          * Calls TailersCount.
          * @function tailersCount
          * @memberof logproto.Querier
@@ -269,11 +266,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Querier.prototype.tailersCount = function tailersCount(request, callback) {
-            return this.rpcCall(tailersCount, $root.logproto.TailersCountRequest, $root.logproto.TailersCountResponse, request, callback);
-        }, "name", { value: "TailersCount" });
+    Object.defineProperty(Querier.prototype.tailersCount = function tailersCount (request, callback) {
+      return this.rpcCall(tailersCount, $root.logproto.TailersCountRequest, $root.logproto.TailersCountResponse, request, callback)
+    }, 'name', { value: 'TailersCount' })
 
-        /**
+    /**
          * Calls TailersCount.
          * @function tailersCount
          * @memberof logproto.Querier
@@ -283,12 +280,11 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        return Querier;
-    })();
+    return Querier
+  })()
 
-    logproto.Ingester = (function() {
-
-        /**
+  logproto.Ingester = (function () {
+    /**
          * Constructs a new Ingester service.
          * @memberof logproto
          * @classdesc Represents an Ingester
@@ -298,13 +294,13 @@ $root.logproto = (function() {
          * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
          * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
          */
-        function Ingester(rpcImpl, requestDelimited, responseDelimited) {
-            $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
-        }
+    function Ingester (rpcImpl, requestDelimited, responseDelimited) {
+      $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited)
+    }
 
-        (Ingester.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Ingester;
+    (Ingester.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Ingester
 
-        /**
+    /**
          * Creates new Ingester service using the specified rpc implementation.
          * @function create
          * @memberof logproto.Ingester
@@ -314,11 +310,11 @@ $root.logproto = (function() {
          * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
          * @returns {Ingester} RPC service. Useful where requests and/or responses are streamed.
          */
-        Ingester.create = function create(rpcImpl, requestDelimited, responseDelimited) {
-            return new this(rpcImpl, requestDelimited, responseDelimited);
-        };
+    Ingester.create = function create (rpcImpl, requestDelimited, responseDelimited) {
+      return new this(rpcImpl, requestDelimited, responseDelimited)
+    }
 
-        /**
+    /**
          * Callback as used by {@link logproto.Ingester#transferChunks}.
          * @memberof logproto.Ingester
          * @typedef TransferChunksCallback
@@ -327,7 +323,7 @@ $root.logproto = (function() {
          * @param {logproto.TransferChunksResponse} [response] TransferChunksResponse
          */
 
-        /**
+    /**
          * Calls TransferChunks.
          * @function transferChunks
          * @memberof logproto.Ingester
@@ -337,11 +333,11 @@ $root.logproto = (function() {
          * @returns {undefined}
          * @variation 1
          */
-        Object.defineProperty(Ingester.prototype.transferChunks = function transferChunks(request, callback) {
-            return this.rpcCall(transferChunks, $root.logproto.TimeSeriesChunk, $root.logproto.TransferChunksResponse, request, callback);
-        }, "name", { value: "TransferChunks" });
+    Object.defineProperty(Ingester.prototype.transferChunks = function transferChunks (request, callback) {
+      return this.rpcCall(transferChunks, $root.logproto.TimeSeriesChunk, $root.logproto.TransferChunksResponse, request, callback)
+    }, 'name', { value: 'TransferChunks' })
 
-        /**
+    /**
          * Calls TransferChunks.
          * @function transferChunks
          * @memberof logproto.Ingester
@@ -351,19 +347,18 @@ $root.logproto = (function() {
          * @variation 2
          */
 
-        return Ingester;
-    })();
+    return Ingester
+  })()
 
-    logproto.PushRequest = (function() {
-
-        /**
+  logproto.PushRequest = (function () {
+    /**
          * Properties of a PushRequest.
          * @memberof logproto
          * @interface IPushRequest
          * @property {Array.<logproto.IStream>|null} [streams] PushRequest streams
          */
 
-        /**
+    /**
          * Constructs a new PushRequest.
          * @memberof logproto
          * @classdesc Represents a PushRequest.
@@ -371,23 +366,24 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IPushRequest=} [properties] Properties to set
          */
-        function PushRequest(properties) {
-            this.streams = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function PushRequest (properties) {
+      this.streams = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * PushRequest streams.
          * @member {Array.<logproto.IStream>} streams
          * @memberof logproto.PushRequest
          * @instance
          */
-        PushRequest.prototype.streams = $util.emptyArray;
+    PushRequest.prototype.streams = $util.emptyArray
 
-        /**
+    /**
          * Creates a new PushRequest instance using the specified properties.
          * @function create
          * @memberof logproto.PushRequest
@@ -395,11 +391,11 @@ $root.logproto = (function() {
          * @param {logproto.IPushRequest=} [properties] Properties to set
          * @returns {logproto.PushRequest} PushRequest instance
          */
-        PushRequest.create = function create(properties) {
-            return new PushRequest(properties);
-        };
+    PushRequest.create = function create (properties) {
+      return new PushRequest(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified PushRequest message. Does not implicitly {@link logproto.PushRequest.verify|verify} messages.
          * @function encode
          * @memberof logproto.PushRequest
@@ -408,16 +404,15 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PushRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.streams != null && message.streams.length)
-                for (var i = 0; i < message.streams.length; ++i)
-                    $root.logproto.Stream.encode(message.streams[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            return writer;
-        };
+    PushRequest.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.streams != null && message.streams.length) {
+        for (var i = 0; i < message.streams.length; ++i) { $root.logproto.Stream.encode(message.streams[i], writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified PushRequest message, length delimited. Does not implicitly {@link logproto.PushRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.PushRequest
@@ -426,11 +421,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PushRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    PushRequest.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a PushRequest message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.PushRequest
@@ -441,27 +436,25 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PushRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.PushRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    if (!(message.streams && message.streams.length))
-                        message.streams = [];
-                    message.streams.push($root.logproto.Stream.decode(reader, reader.uint32()));
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    PushRequest.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.PushRequest()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            if (!(message.streams && message.streams.length)) { message.streams = [] }
+            message.streams.push($root.logproto.Stream.decode(reader, reader.uint32()))
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a PushRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.PushRequest
@@ -471,13 +464,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PushRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    PushRequest.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a PushRequest message.
          * @function verify
          * @memberof logproto.PushRequest
@@ -485,22 +477,19 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PushRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.streams != null && message.hasOwnProperty("streams")) {
-                if (!Array.isArray(message.streams))
-                    return "streams: array expected";
-                for (var i = 0; i < message.streams.length; ++i) {
-                    var error = $root.logproto.Stream.verify(message.streams[i]);
-                    if (error)
-                        return "streams." + error;
-                }
-            }
-            return null;
-        };
+    PushRequest.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.streams != null && message.hasOwnProperty('streams')) {
+        if (!Array.isArray(message.streams)) { return 'streams: array expected' }
+        for (var i = 0; i < message.streams.length; ++i) {
+          var error = $root.logproto.Stream.verify(message.streams[i])
+          if (error) { return 'streams.' + error }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a PushRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.PushRequest
@@ -508,24 +497,21 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.PushRequest} PushRequest
          */
-        PushRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.PushRequest)
-                return object;
-            var message = new $root.logproto.PushRequest();
-            if (object.streams) {
-                if (!Array.isArray(object.streams))
-                    throw TypeError(".logproto.PushRequest.streams: array expected");
-                message.streams = [];
-                for (var i = 0; i < object.streams.length; ++i) {
-                    if (typeof object.streams[i] !== "object")
-                        throw TypeError(".logproto.PushRequest.streams: object expected");
-                    message.streams[i] = $root.logproto.Stream.fromObject(object.streams[i]);
-                }
-            }
-            return message;
-        };
+    PushRequest.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.PushRequest) { return object }
+      var message = new $root.logproto.PushRequest()
+      if (object.streams) {
+        if (!Array.isArray(object.streams)) { throw TypeError('.logproto.PushRequest.streams: array expected') }
+        message.streams = []
+        for (var i = 0; i < object.streams.length; ++i) {
+          if (typeof object.streams[i] !== 'object') { throw TypeError('.logproto.PushRequest.streams: object expected') }
+          message.streams[i] = $root.logproto.Stream.fromObject(object.streams[i])
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a PushRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.PushRequest
@@ -534,43 +520,39 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PushRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.streams = [];
-            if (message.streams && message.streams.length) {
-                object.streams = [];
-                for (var j = 0; j < message.streams.length; ++j)
-                    object.streams[j] = $root.logproto.Stream.toObject(message.streams[j], options);
-            }
-            return object;
-        };
+    PushRequest.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.streams = [] }
+      if (message.streams && message.streams.length) {
+        object.streams = []
+        for (var j = 0; j < message.streams.length; ++j) { object.streams[j] = $root.logproto.Stream.toObject(message.streams[j], options) }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this PushRequest to JSON.
          * @function toJSON
          * @memberof logproto.PushRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PushRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    PushRequest.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return PushRequest;
-    })();
+    return PushRequest
+  })()
 
-    logproto.PushResponse = (function() {
-
-        /**
+  logproto.PushResponse = (function () {
+    /**
          * Properties of a PushResponse.
          * @memberof logproto
          * @interface IPushResponse
          */
 
-        /**
+    /**
          * Constructs a new PushResponse.
          * @memberof logproto
          * @classdesc Represents a PushResponse.
@@ -578,14 +560,15 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IPushResponse=} [properties] Properties to set
          */
-        function PushResponse(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function PushResponse (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * Creates a new PushResponse instance using the specified properties.
          * @function create
          * @memberof logproto.PushResponse
@@ -593,11 +576,11 @@ $root.logproto = (function() {
          * @param {logproto.IPushResponse=} [properties] Properties to set
          * @returns {logproto.PushResponse} PushResponse instance
          */
-        PushResponse.create = function create(properties) {
-            return new PushResponse(properties);
-        };
+    PushResponse.create = function create (properties) {
+      return new PushResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified PushResponse message. Does not implicitly {@link logproto.PushResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.PushResponse
@@ -606,13 +589,12 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PushResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            return writer;
-        };
+    PushResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified PushResponse message, length delimited. Does not implicitly {@link logproto.PushResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.PushResponse
@@ -621,11 +603,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PushResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    PushResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a PushResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.PushResponse
@@ -636,22 +618,21 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PushResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.PushResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    PushResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.PushResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a PushResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.PushResponse
@@ -661,13 +642,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PushResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    PushResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a PushResponse message.
          * @function verify
          * @memberof logproto.PushResponse
@@ -675,13 +655,12 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PushResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            return null;
-        };
+    PushResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      return null
+    }
 
-        /**
+    /**
          * Creates a PushResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.PushResponse
@@ -689,13 +668,12 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.PushResponse} PushResponse
          */
-        PushResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.PushResponse)
-                return object;
-            return new $root.logproto.PushResponse();
-        };
+    PushResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.PushResponse) { return object }
+      return new $root.logproto.PushResponse()
+    }
 
-        /**
+    /**
          * Creates a plain object from a PushResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.PushResponse
@@ -704,27 +682,26 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PushResponse.toObject = function toObject() {
-            return {};
-        };
+    PushResponse.toObject = function toObject () {
+      return {}
+    }
 
-        /**
+    /**
          * Converts this PushResponse to JSON.
          * @function toJSON
          * @memberof logproto.PushResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PushResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    PushResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return PushResponse;
-    })();
+    return PushResponse
+  })()
 
-    logproto.QueryRequest = (function() {
-
-        /**
+  logproto.QueryRequest = (function () {
+    /**
          * Properties of a QueryRequest.
          * @memberof logproto
          * @interface IQueryRequest
@@ -735,7 +712,7 @@ $root.logproto = (function() {
          * @property {logproto.Direction|null} [direction] QueryRequest direction
          */
 
-        /**
+    /**
          * Constructs a new QueryRequest.
          * @memberof logproto
          * @classdesc Represents a QueryRequest.
@@ -743,54 +720,55 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IQueryRequest=} [properties] Properties to set
          */
-        function QueryRequest(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function QueryRequest (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * QueryRequest selector.
          * @member {string} selector
          * @memberof logproto.QueryRequest
          * @instance
          */
-        QueryRequest.prototype.selector = "";
+    QueryRequest.prototype.selector = ''
 
-        /**
+    /**
          * QueryRequest limit.
          * @member {number} limit
          * @memberof logproto.QueryRequest
          * @instance
          */
-        QueryRequest.prototype.limit = 0;
+    QueryRequest.prototype.limit = 0
 
-        /**
+    /**
          * QueryRequest start.
          * @member {google.protobuf.ITimestamp|null|undefined} start
          * @memberof logproto.QueryRequest
          * @instance
          */
-        QueryRequest.prototype.start = null;
+    QueryRequest.prototype.start = null
 
-        /**
+    /**
          * QueryRequest end.
          * @member {google.protobuf.ITimestamp|null|undefined} end
          * @memberof logproto.QueryRequest
          * @instance
          */
-        QueryRequest.prototype.end = null;
+    QueryRequest.prototype.end = null
 
-        /**
+    /**
          * QueryRequest direction.
          * @member {logproto.Direction} direction
          * @memberof logproto.QueryRequest
          * @instance
          */
-        QueryRequest.prototype.direction = 0;
+    QueryRequest.prototype.direction = 0
 
-        /**
+    /**
          * Creates a new QueryRequest instance using the specified properties.
          * @function create
          * @memberof logproto.QueryRequest
@@ -798,11 +776,11 @@ $root.logproto = (function() {
          * @param {logproto.IQueryRequest=} [properties] Properties to set
          * @returns {logproto.QueryRequest} QueryRequest instance
          */
-        QueryRequest.create = function create(properties) {
-            return new QueryRequest(properties);
-        };
+    QueryRequest.create = function create (properties) {
+      return new QueryRequest(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified QueryRequest message. Does not implicitly {@link logproto.QueryRequest.verify|verify} messages.
          * @function encode
          * @memberof logproto.QueryRequest
@@ -811,23 +789,17 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        QueryRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.selector != null && message.hasOwnProperty("selector"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.selector);
-            if (message.limit != null && message.hasOwnProperty("limit"))
-                writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.limit);
-            if (message.start != null && message.hasOwnProperty("start"))
-                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-            if (message.end != null && message.hasOwnProperty("end"))
-                $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-            if (message.direction != null && message.hasOwnProperty("direction"))
-                writer.uint32(/* id 5, wireType 0 =*/40).int32(message.direction);
-            return writer;
-        };
+    QueryRequest.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.selector != null && message.hasOwnProperty('selector')) { writer.uint32(/* id 1, wireType 2 = */10).string(message.selector) }
+      if (message.limit != null && message.hasOwnProperty('limit')) { writer.uint32(/* id 2, wireType 0 = */16).uint32(message.limit) }
+      if (message.start != null && message.hasOwnProperty('start')) { $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 3, wireType 2 = */26).fork()).ldelim() }
+      if (message.end != null && message.hasOwnProperty('end')) { $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 4, wireType 2 = */34).fork()).ldelim() }
+      if (message.direction != null && message.hasOwnProperty('direction')) { writer.uint32(/* id 5, wireType 0 = */40).int32(message.direction) }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified QueryRequest message, length delimited. Does not implicitly {@link logproto.QueryRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.QueryRequest
@@ -836,11 +808,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        QueryRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    QueryRequest.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a QueryRequest message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.QueryRequest
@@ -851,37 +823,36 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        QueryRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.QueryRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.selector = reader.string();
-                    break;
-                case 2:
-                    message.limit = reader.uint32();
-                    break;
-                case 3:
-                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 4:
-                    message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 5:
-                    message.direction = reader.int32();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    QueryRequest.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.QueryRequest()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.selector = reader.string()
+            break
+          case 2:
+            message.limit = reader.uint32()
+            break
+          case 3:
+            message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 4:
+            message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 5:
+            message.direction = reader.int32()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a QueryRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.QueryRequest
@@ -891,13 +862,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        QueryRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    QueryRequest.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a QueryRequest message.
          * @function verify
          * @memberof logproto.QueryRequest
@@ -905,37 +875,35 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        QueryRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.selector != null && message.hasOwnProperty("selector"))
-                if (!$util.isString(message.selector))
-                    return "selector: string expected";
-            if (message.limit != null && message.hasOwnProperty("limit"))
-                if (!$util.isInteger(message.limit))
-                    return "limit: integer expected";
-            if (message.start != null && message.hasOwnProperty("start")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.start);
-                if (error)
-                    return "start." + error;
-            }
-            if (message.end != null && message.hasOwnProperty("end")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.end);
-                if (error)
-                    return "end." + error;
-            }
-            if (message.direction != null && message.hasOwnProperty("direction"))
-                switch (message.direction) {
-                default:
-                    return "direction: enum value expected";
-                case 0:
-                case 1:
-                    break;
-                }
-            return null;
-        };
+    QueryRequest.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.selector != null && message.hasOwnProperty('selector')) {
+        if (!$util.isString(message.selector)) { return 'selector: string expected' }
+      }
+      if (message.limit != null && message.hasOwnProperty('limit')) {
+        if (!$util.isInteger(message.limit)) { return 'limit: integer expected' }
+      }
+      if (message.start != null && message.hasOwnProperty('start')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.start)
+        if (error) { return 'start.' + error }
+      }
+      if (message.end != null && message.hasOwnProperty('end')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.end)
+        if (error) { return 'end.' + error }
+      }
+      if (message.direction != null && message.hasOwnProperty('direction')) {
+        switch (message.direction) {
+          default:
+            return 'direction: enum value expected'
+          case 0:
+          case 1:
+            break
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a QueryRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.QueryRequest
@@ -943,38 +911,33 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.QueryRequest} QueryRequest
          */
-        QueryRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.QueryRequest)
-                return object;
-            var message = new $root.logproto.QueryRequest();
-            if (object.selector != null)
-                message.selector = String(object.selector);
-            if (object.limit != null)
-                message.limit = object.limit >>> 0;
-            if (object.start != null) {
-                if (typeof object.start !== "object")
-                    throw TypeError(".logproto.QueryRequest.start: object expected");
-                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
-            }
-            if (object.end != null) {
-                if (typeof object.end !== "object")
-                    throw TypeError(".logproto.QueryRequest.end: object expected");
-                message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
-            }
-            switch (object.direction) {
-            case "FORWARD":
-            case 0:
-                message.direction = 0;
-                break;
-            case "BACKWARD":
-            case 1:
-                message.direction = 1;
-                break;
-            }
-            return message;
-        };
+    QueryRequest.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.QueryRequest) { return object }
+      var message = new $root.logproto.QueryRequest()
+      if (object.selector != null) { message.selector = String(object.selector) }
+      if (object.limit != null) { message.limit = object.limit >>> 0 }
+      if (object.start != null) {
+        if (typeof object.start !== 'object') { throw TypeError('.logproto.QueryRequest.start: object expected') }
+        message.start = $root.google.protobuf.Timestamp.fromObject(object.start)
+      }
+      if (object.end != null) {
+        if (typeof object.end !== 'object') { throw TypeError('.logproto.QueryRequest.end: object expected') }
+        message.end = $root.google.protobuf.Timestamp.fromObject(object.end)
+      }
+      switch (object.direction) {
+        case 'FORWARD':
+        case 0:
+          message.direction = 0
+          break
+        case 'BACKWARD':
+        case 1:
+          message.direction = 1
+          break
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a QueryRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.QueryRequest
@@ -983,68 +946,61 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        QueryRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.selector = "";
-                object.limit = 0;
-                object.start = null;
-                object.end = null;
-                object.direction = options.enums === String ? "FORWARD" : 0;
-            }
-            if (message.selector != null && message.hasOwnProperty("selector"))
-                object.selector = message.selector;
-            if (message.limit != null && message.hasOwnProperty("limit"))
-                object.limit = message.limit;
-            if (message.start != null && message.hasOwnProperty("start"))
-                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
-            if (message.end != null && message.hasOwnProperty("end"))
-                object.end = $root.google.protobuf.Timestamp.toObject(message.end, options);
-            if (message.direction != null && message.hasOwnProperty("direction"))
-                object.direction = options.enums === String ? $root.logproto.Direction[message.direction] : message.direction;
-            return object;
-        };
+    QueryRequest.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        object.selector = ''
+        object.limit = 0
+        object.start = null
+        object.end = null
+        object.direction = options.enums === String ? 'FORWARD' : 0
+      }
+      if (message.selector != null && message.hasOwnProperty('selector')) { object.selector = message.selector }
+      if (message.limit != null && message.hasOwnProperty('limit')) { object.limit = message.limit }
+      if (message.start != null && message.hasOwnProperty('start')) { object.start = $root.google.protobuf.Timestamp.toObject(message.start, options) }
+      if (message.end != null && message.hasOwnProperty('end')) { object.end = $root.google.protobuf.Timestamp.toObject(message.end, options) }
+      if (message.direction != null && message.hasOwnProperty('direction')) { object.direction = options.enums === String ? $root.logproto.Direction[message.direction] : message.direction }
+      return object
+    }
 
-        /**
+    /**
          * Converts this QueryRequest to JSON.
          * @function toJSON
          * @memberof logproto.QueryRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        QueryRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    QueryRequest.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return QueryRequest;
-    })();
+    return QueryRequest
+  })()
 
-    /**
+  /**
      * Direction enum.
      * @name logproto.Direction
      * @enum {string}
      * @property {number} FORWARD=0 FORWARD value
      * @property {number} BACKWARD=1 BACKWARD value
      */
-    logproto.Direction = (function() {
-        var valuesById = {}, values = Object.create(valuesById);
-        values[valuesById[0] = "FORWARD"] = 0;
-        values[valuesById[1] = "BACKWARD"] = 1;
-        return values;
-    })();
+  logproto.Direction = (function () {
+    var valuesById = {}; var values = Object.create(valuesById)
+    values[valuesById[0] = 'FORWARD'] = 0
+    values[valuesById[1] = 'BACKWARD'] = 1
+    return values
+  })()
 
-    logproto.QueryResponse = (function() {
-
-        /**
+  logproto.QueryResponse = (function () {
+    /**
          * Properties of a QueryResponse.
          * @memberof logproto
          * @interface IQueryResponse
          * @property {Array.<logproto.IStream>|null} [streams] QueryResponse streams
          */
 
-        /**
+    /**
          * Constructs a new QueryResponse.
          * @memberof logproto
          * @classdesc Represents a QueryResponse.
@@ -1052,23 +1008,24 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IQueryResponse=} [properties] Properties to set
          */
-        function QueryResponse(properties) {
-            this.streams = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function QueryResponse (properties) {
+      this.streams = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * QueryResponse streams.
          * @member {Array.<logproto.IStream>} streams
          * @memberof logproto.QueryResponse
          * @instance
          */
-        QueryResponse.prototype.streams = $util.emptyArray;
+    QueryResponse.prototype.streams = $util.emptyArray
 
-        /**
+    /**
          * Creates a new QueryResponse instance using the specified properties.
          * @function create
          * @memberof logproto.QueryResponse
@@ -1076,11 +1033,11 @@ $root.logproto = (function() {
          * @param {logproto.IQueryResponse=} [properties] Properties to set
          * @returns {logproto.QueryResponse} QueryResponse instance
          */
-        QueryResponse.create = function create(properties) {
-            return new QueryResponse(properties);
-        };
+    QueryResponse.create = function create (properties) {
+      return new QueryResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified QueryResponse message. Does not implicitly {@link logproto.QueryResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.QueryResponse
@@ -1089,16 +1046,15 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        QueryResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.streams != null && message.streams.length)
-                for (var i = 0; i < message.streams.length; ++i)
-                    $root.logproto.Stream.encode(message.streams[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            return writer;
-        };
+    QueryResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.streams != null && message.streams.length) {
+        for (var i = 0; i < message.streams.length; ++i) { $root.logproto.Stream.encode(message.streams[i], writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified QueryResponse message, length delimited. Does not implicitly {@link logproto.QueryResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.QueryResponse
@@ -1107,11 +1063,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        QueryResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    QueryResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a QueryResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.QueryResponse
@@ -1122,27 +1078,25 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        QueryResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.QueryResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    if (!(message.streams && message.streams.length))
-                        message.streams = [];
-                    message.streams.push($root.logproto.Stream.decode(reader, reader.uint32()));
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    QueryResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.QueryResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            if (!(message.streams && message.streams.length)) { message.streams = [] }
+            message.streams.push($root.logproto.Stream.decode(reader, reader.uint32()))
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a QueryResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.QueryResponse
@@ -1152,13 +1106,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        QueryResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    QueryResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a QueryResponse message.
          * @function verify
          * @memberof logproto.QueryResponse
@@ -1166,22 +1119,19 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        QueryResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.streams != null && message.hasOwnProperty("streams")) {
-                if (!Array.isArray(message.streams))
-                    return "streams: array expected";
-                for (var i = 0; i < message.streams.length; ++i) {
-                    var error = $root.logproto.Stream.verify(message.streams[i]);
-                    if (error)
-                        return "streams." + error;
-                }
-            }
-            return null;
-        };
+    QueryResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.streams != null && message.hasOwnProperty('streams')) {
+        if (!Array.isArray(message.streams)) { return 'streams: array expected' }
+        for (var i = 0; i < message.streams.length; ++i) {
+          var error = $root.logproto.Stream.verify(message.streams[i])
+          if (error) { return 'streams.' + error }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a QueryResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.QueryResponse
@@ -1189,24 +1139,21 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.QueryResponse} QueryResponse
          */
-        QueryResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.QueryResponse)
-                return object;
-            var message = new $root.logproto.QueryResponse();
-            if (object.streams) {
-                if (!Array.isArray(object.streams))
-                    throw TypeError(".logproto.QueryResponse.streams: array expected");
-                message.streams = [];
-                for (var i = 0; i < object.streams.length; ++i) {
-                    if (typeof object.streams[i] !== "object")
-                        throw TypeError(".logproto.QueryResponse.streams: object expected");
-                    message.streams[i] = $root.logproto.Stream.fromObject(object.streams[i]);
-                }
-            }
-            return message;
-        };
+    QueryResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.QueryResponse) { return object }
+      var message = new $root.logproto.QueryResponse()
+      if (object.streams) {
+        if (!Array.isArray(object.streams)) { throw TypeError('.logproto.QueryResponse.streams: array expected') }
+        message.streams = []
+        for (var i = 0; i < object.streams.length; ++i) {
+          if (typeof object.streams[i] !== 'object') { throw TypeError('.logproto.QueryResponse.streams: object expected') }
+          message.streams[i] = $root.logproto.Stream.fromObject(object.streams[i])
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a QueryResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.QueryResponse
@@ -1215,37 +1162,33 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        QueryResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.streams = [];
-            if (message.streams && message.streams.length) {
-                object.streams = [];
-                for (var j = 0; j < message.streams.length; ++j)
-                    object.streams[j] = $root.logproto.Stream.toObject(message.streams[j], options);
-            }
-            return object;
-        };
+    QueryResponse.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.streams = [] }
+      if (message.streams && message.streams.length) {
+        object.streams = []
+        for (var j = 0; j < message.streams.length; ++j) { object.streams[j] = $root.logproto.Stream.toObject(message.streams[j], options) }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this QueryResponse to JSON.
          * @function toJSON
          * @memberof logproto.QueryResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        QueryResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    QueryResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return QueryResponse;
-    })();
+    return QueryResponse
+  })()
 
-    logproto.LabelRequest = (function() {
-
-        /**
+  logproto.LabelRequest = (function () {
+    /**
          * Properties of a LabelRequest.
          * @memberof logproto
          * @interface ILabelRequest
@@ -1255,7 +1198,7 @@ $root.logproto = (function() {
          * @property {google.protobuf.ITimestamp|null} [end] LabelRequest end
          */
 
-        /**
+    /**
          * Constructs a new LabelRequest.
          * @memberof logproto
          * @classdesc Represents a LabelRequest.
@@ -1263,46 +1206,47 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ILabelRequest=} [properties] Properties to set
          */
-        function LabelRequest(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function LabelRequest (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * LabelRequest name.
          * @member {string} name
          * @memberof logproto.LabelRequest
          * @instance
          */
-        LabelRequest.prototype.name = "";
+    LabelRequest.prototype.name = ''
 
-        /**
+    /**
          * LabelRequest values.
          * @member {boolean} values
          * @memberof logproto.LabelRequest
          * @instance
          */
-        LabelRequest.prototype.values = false;
+    LabelRequest.prototype.values = false
 
-        /**
+    /**
          * LabelRequest start.
          * @member {google.protobuf.ITimestamp|null|undefined} start
          * @memberof logproto.LabelRequest
          * @instance
          */
-        LabelRequest.prototype.start = null;
+    LabelRequest.prototype.start = null
 
-        /**
+    /**
          * LabelRequest end.
          * @member {google.protobuf.ITimestamp|null|undefined} end
          * @memberof logproto.LabelRequest
          * @instance
          */
-        LabelRequest.prototype.end = null;
+    LabelRequest.prototype.end = null
 
-        /**
+    /**
          * Creates a new LabelRequest instance using the specified properties.
          * @function create
          * @memberof logproto.LabelRequest
@@ -1310,11 +1254,11 @@ $root.logproto = (function() {
          * @param {logproto.ILabelRequest=} [properties] Properties to set
          * @returns {logproto.LabelRequest} LabelRequest instance
          */
-        LabelRequest.create = function create(properties) {
-            return new LabelRequest(properties);
-        };
+    LabelRequest.create = function create (properties) {
+      return new LabelRequest(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified LabelRequest message. Does not implicitly {@link logproto.LabelRequest.verify|verify} messages.
          * @function encode
          * @memberof logproto.LabelRequest
@@ -1323,21 +1267,16 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        LabelRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.name != null && message.hasOwnProperty("name"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-            if (message.values != null && message.hasOwnProperty("values"))
-                writer.uint32(/* id 2, wireType 0 =*/16).bool(message.values);
-            if (message.start != null && message.hasOwnProperty("start"))
-                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-            if (message.end != null && message.hasOwnProperty("end"))
-                $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-            return writer;
-        };
+    LabelRequest.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.name != null && message.hasOwnProperty('name')) { writer.uint32(/* id 1, wireType 2 = */10).string(message.name) }
+      if (message.values != null && message.hasOwnProperty('values')) { writer.uint32(/* id 2, wireType 0 = */16).bool(message.values) }
+      if (message.start != null && message.hasOwnProperty('start')) { $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 3, wireType 2 = */26).fork()).ldelim() }
+      if (message.end != null && message.hasOwnProperty('end')) { $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 4, wireType 2 = */34).fork()).ldelim() }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified LabelRequest message, length delimited. Does not implicitly {@link logproto.LabelRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.LabelRequest
@@ -1346,11 +1285,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        LabelRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    LabelRequest.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a LabelRequest message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.LabelRequest
@@ -1361,34 +1300,33 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        LabelRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.LabelRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.name = reader.string();
-                    break;
-                case 2:
-                    message.values = reader.bool();
-                    break;
-                case 3:
-                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 4:
-                    message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    LabelRequest.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.LabelRequest()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.name = reader.string()
+            break
+          case 2:
+            message.values = reader.bool()
+            break
+          case 3:
+            message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 4:
+            message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a LabelRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.LabelRequest
@@ -1398,13 +1336,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        LabelRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    LabelRequest.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a LabelRequest message.
          * @function verify
          * @memberof logproto.LabelRequest
@@ -1412,29 +1349,26 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        LabelRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.name != null && message.hasOwnProperty("name"))
-                if (!$util.isString(message.name))
-                    return "name: string expected";
-            if (message.values != null && message.hasOwnProperty("values"))
-                if (typeof message.values !== "boolean")
-                    return "values: boolean expected";
-            if (message.start != null && message.hasOwnProperty("start")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.start);
-                if (error)
-                    return "start." + error;
-            }
-            if (message.end != null && message.hasOwnProperty("end")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.end);
-                if (error)
-                    return "end." + error;
-            }
-            return null;
-        };
+    LabelRequest.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.name != null && message.hasOwnProperty('name')) {
+        if (!$util.isString(message.name)) { return 'name: string expected' }
+      }
+      if (message.values != null && message.hasOwnProperty('values')) {
+        if (typeof message.values !== 'boolean') { return 'values: boolean expected' }
+      }
+      if (message.start != null && message.hasOwnProperty('start')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.start)
+        if (error) { return 'start.' + error }
+      }
+      if (message.end != null && message.hasOwnProperty('end')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.end)
+        if (error) { return 'end.' + error }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a LabelRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.LabelRequest
@@ -1442,28 +1376,23 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.LabelRequest} LabelRequest
          */
-        LabelRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.LabelRequest)
-                return object;
-            var message = new $root.logproto.LabelRequest();
-            if (object.name != null)
-                message.name = String(object.name);
-            if (object.values != null)
-                message.values = Boolean(object.values);
-            if (object.start != null) {
-                if (typeof object.start !== "object")
-                    throw TypeError(".logproto.LabelRequest.start: object expected");
-                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
-            }
-            if (object.end != null) {
-                if (typeof object.end !== "object")
-                    throw TypeError(".logproto.LabelRequest.end: object expected");
-                message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
-            }
-            return message;
-        };
+    LabelRequest.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.LabelRequest) { return object }
+      var message = new $root.logproto.LabelRequest()
+      if (object.name != null) { message.name = String(object.name) }
+      if (object.values != null) { message.values = Boolean(object.values) }
+      if (object.start != null) {
+        if (typeof object.start !== 'object') { throw TypeError('.logproto.LabelRequest.start: object expected') }
+        message.start = $root.google.protobuf.Timestamp.fromObject(object.start)
+      }
+      if (object.end != null) {
+        if (typeof object.end !== 'object') { throw TypeError('.logproto.LabelRequest.end: object expected') }
+        message.end = $root.google.protobuf.Timestamp.fromObject(object.end)
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a LabelRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.LabelRequest
@@ -1472,51 +1401,45 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        LabelRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.name = "";
-                object.values = false;
-                object.start = null;
-                object.end = null;
-            }
-            if (message.name != null && message.hasOwnProperty("name"))
-                object.name = message.name;
-            if (message.values != null && message.hasOwnProperty("values"))
-                object.values = message.values;
-            if (message.start != null && message.hasOwnProperty("start"))
-                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
-            if (message.end != null && message.hasOwnProperty("end"))
-                object.end = $root.google.protobuf.Timestamp.toObject(message.end, options);
-            return object;
-        };
+    LabelRequest.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        object.name = ''
+        object.values = false
+        object.start = null
+        object.end = null
+      }
+      if (message.name != null && message.hasOwnProperty('name')) { object.name = message.name }
+      if (message.values != null && message.hasOwnProperty('values')) { object.values = message.values }
+      if (message.start != null && message.hasOwnProperty('start')) { object.start = $root.google.protobuf.Timestamp.toObject(message.start, options) }
+      if (message.end != null && message.hasOwnProperty('end')) { object.end = $root.google.protobuf.Timestamp.toObject(message.end, options) }
+      return object
+    }
 
-        /**
+    /**
          * Converts this LabelRequest to JSON.
          * @function toJSON
          * @memberof logproto.LabelRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        LabelRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    LabelRequest.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return LabelRequest;
-    })();
+    return LabelRequest
+  })()
 
-    logproto.LabelResponse = (function() {
-
-        /**
+  logproto.LabelResponse = (function () {
+    /**
          * Properties of a LabelResponse.
          * @memberof logproto
          * @interface ILabelResponse
          * @property {Array.<string>|null} [values] LabelResponse values
          */
 
-        /**
+    /**
          * Constructs a new LabelResponse.
          * @memberof logproto
          * @classdesc Represents a LabelResponse.
@@ -1524,23 +1447,24 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ILabelResponse=} [properties] Properties to set
          */
-        function LabelResponse(properties) {
-            this.values = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function LabelResponse (properties) {
+      this.values = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * LabelResponse values.
          * @member {Array.<string>} values
          * @memberof logproto.LabelResponse
          * @instance
          */
-        LabelResponse.prototype.values = $util.emptyArray;
+    LabelResponse.prototype.values = $util.emptyArray
 
-        /**
+    /**
          * Creates a new LabelResponse instance using the specified properties.
          * @function create
          * @memberof logproto.LabelResponse
@@ -1548,11 +1472,11 @@ $root.logproto = (function() {
          * @param {logproto.ILabelResponse=} [properties] Properties to set
          * @returns {logproto.LabelResponse} LabelResponse instance
          */
-        LabelResponse.create = function create(properties) {
-            return new LabelResponse(properties);
-        };
+    LabelResponse.create = function create (properties) {
+      return new LabelResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified LabelResponse message. Does not implicitly {@link logproto.LabelResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.LabelResponse
@@ -1561,16 +1485,15 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        LabelResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.values != null && message.values.length)
-                for (var i = 0; i < message.values.length; ++i)
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.values[i]);
-            return writer;
-        };
+    LabelResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.values != null && message.values.length) {
+        for (var i = 0; i < message.values.length; ++i) { writer.uint32(/* id 1, wireType 2 = */10).string(message.values[i]) }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified LabelResponse message, length delimited. Does not implicitly {@link logproto.LabelResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.LabelResponse
@@ -1579,11 +1502,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        LabelResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    LabelResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a LabelResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.LabelResponse
@@ -1594,27 +1517,25 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        LabelResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.LabelResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    if (!(message.values && message.values.length))
-                        message.values = [];
-                    message.values.push(reader.string());
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    LabelResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.LabelResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            if (!(message.values && message.values.length)) { message.values = [] }
+            message.values.push(reader.string())
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a LabelResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.LabelResponse
@@ -1624,13 +1545,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        LabelResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    LabelResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a LabelResponse message.
          * @function verify
          * @memberof logproto.LabelResponse
@@ -1638,20 +1558,18 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        LabelResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.values != null && message.hasOwnProperty("values")) {
-                if (!Array.isArray(message.values))
-                    return "values: array expected";
-                for (var i = 0; i < message.values.length; ++i)
-                    if (!$util.isString(message.values[i]))
-                        return "values: string[] expected";
-            }
-            return null;
-        };
+    LabelResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.values != null && message.hasOwnProperty('values')) {
+        if (!Array.isArray(message.values)) { return 'values: array expected' }
+        for (var i = 0; i < message.values.length; ++i) {
+          if (!$util.isString(message.values[i])) { return 'values: string[] expected' }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a LabelResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.LabelResponse
@@ -1659,21 +1577,18 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.LabelResponse} LabelResponse
          */
-        LabelResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.LabelResponse)
-                return object;
-            var message = new $root.logproto.LabelResponse();
-            if (object.values) {
-                if (!Array.isArray(object.values))
-                    throw TypeError(".logproto.LabelResponse.values: array expected");
-                message.values = [];
-                for (var i = 0; i < object.values.length; ++i)
-                    message.values[i] = String(object.values[i]);
-            }
-            return message;
-        };
+    LabelResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.LabelResponse) { return object }
+      var message = new $root.logproto.LabelResponse()
+      if (object.values) {
+        if (!Array.isArray(object.values)) { throw TypeError('.logproto.LabelResponse.values: array expected') }
+        message.values = []
+        for (var i = 0; i < object.values.length; ++i) { message.values[i] = String(object.values[i]) }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a LabelResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.LabelResponse
@@ -1682,37 +1597,33 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        LabelResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.values = [];
-            if (message.values && message.values.length) {
-                object.values = [];
-                for (var j = 0; j < message.values.length; ++j)
-                    object.values[j] = message.values[j];
-            }
-            return object;
-        };
+    LabelResponse.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.values = [] }
+      if (message.values && message.values.length) {
+        object.values = []
+        for (var j = 0; j < message.values.length; ++j) { object.values[j] = message.values[j] }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this LabelResponse to JSON.
          * @function toJSON
          * @memberof logproto.LabelResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        LabelResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    LabelResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return LabelResponse;
-    })();
+    return LabelResponse
+  })()
 
-    logproto.Stream = (function() {
-
-        /**
+  logproto.Stream = (function () {
+    /**
          * Properties of a Stream.
          * @memberof logproto
          * @interface IStream
@@ -1720,7 +1631,7 @@ $root.logproto = (function() {
          * @property {Array.<logproto.IEntry>|null} [entries] Stream entries
          */
 
-        /**
+    /**
          * Constructs a new Stream.
          * @memberof logproto
          * @classdesc Represents a Stream.
@@ -1728,31 +1639,32 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IStream=} [properties] Properties to set
          */
-        function Stream(properties) {
-            this.entries = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function Stream (properties) {
+      this.entries = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * Stream labels.
          * @member {string} labels
          * @memberof logproto.Stream
          * @instance
          */
-        Stream.prototype.labels = "";
+    Stream.prototype.labels = ''
 
-        /**
+    /**
          * Stream entries.
          * @member {Array.<logproto.IEntry>} entries
          * @memberof logproto.Stream
          * @instance
          */
-        Stream.prototype.entries = $util.emptyArray;
+    Stream.prototype.entries = $util.emptyArray
 
-        /**
+    /**
          * Creates a new Stream instance using the specified properties.
          * @function create
          * @memberof logproto.Stream
@@ -1760,11 +1672,11 @@ $root.logproto = (function() {
          * @param {logproto.IStream=} [properties] Properties to set
          * @returns {logproto.Stream} Stream instance
          */
-        Stream.create = function create(properties) {
-            return new Stream(properties);
-        };
+    Stream.create = function create (properties) {
+      return new Stream(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified Stream message. Does not implicitly {@link logproto.Stream.verify|verify} messages.
          * @function encode
          * @memberof logproto.Stream
@@ -1773,18 +1685,16 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Stream.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.labels);
-            if (message.entries != null && message.entries.length)
-                for (var i = 0; i < message.entries.length; ++i)
-                    $root.logproto.Entry.encode(message.entries[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-            return writer;
-        };
+    Stream.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.labels != null && message.hasOwnProperty('labels')) { writer.uint32(/* id 1, wireType 2 = */10).string(message.labels) }
+      if (message.entries != null && message.entries.length) {
+        for (var i = 0; i < message.entries.length; ++i) { $root.logproto.Entry.encode(message.entries[i], writer.uint32(/* id 2, wireType 2 = */18).fork()).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified Stream message, length delimited. Does not implicitly {@link logproto.Stream.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.Stream
@@ -1793,11 +1703,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Stream.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    Stream.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a Stream message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.Stream
@@ -1808,30 +1718,28 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Stream.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.Stream();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.labels = reader.string();
-                    break;
-                case 2:
-                    if (!(message.entries && message.entries.length))
-                        message.entries = [];
-                    message.entries.push($root.logproto.Entry.decode(reader, reader.uint32()));
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    Stream.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.Stream()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.labels = reader.string()
+            break
+          case 2:
+            if (!(message.entries && message.entries.length)) { message.entries = [] }
+            message.entries.push($root.logproto.Entry.decode(reader, reader.uint32()))
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a Stream message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.Stream
@@ -1841,13 +1749,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Stream.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    Stream.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a Stream message.
          * @function verify
          * @memberof logproto.Stream
@@ -1855,25 +1762,22 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        Stream.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                if (!$util.isString(message.labels))
-                    return "labels: string expected";
-            if (message.entries != null && message.hasOwnProperty("entries")) {
-                if (!Array.isArray(message.entries))
-                    return "entries: array expected";
-                for (var i = 0; i < message.entries.length; ++i) {
-                    var error = $root.logproto.Entry.verify(message.entries[i]);
-                    if (error)
-                        return "entries." + error;
-                }
-            }
-            return null;
-        };
+    Stream.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.labels != null && message.hasOwnProperty('labels')) {
+        if (!$util.isString(message.labels)) { return 'labels: string expected' }
+      }
+      if (message.entries != null && message.hasOwnProperty('entries')) {
+        if (!Array.isArray(message.entries)) { return 'entries: array expected' }
+        for (var i = 0; i < message.entries.length; ++i) {
+          var error = $root.logproto.Entry.verify(message.entries[i])
+          if (error) { return 'entries.' + error }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a Stream message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.Stream
@@ -1881,26 +1785,22 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.Stream} Stream
          */
-        Stream.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.Stream)
-                return object;
-            var message = new $root.logproto.Stream();
-            if (object.labels != null)
-                message.labels = String(object.labels);
-            if (object.entries) {
-                if (!Array.isArray(object.entries))
-                    throw TypeError(".logproto.Stream.entries: array expected");
-                message.entries = [];
-                for (var i = 0; i < object.entries.length; ++i) {
-                    if (typeof object.entries[i] !== "object")
-                        throw TypeError(".logproto.Stream.entries: object expected");
-                    message.entries[i] = $root.logproto.Entry.fromObject(object.entries[i]);
-                }
-            }
-            return message;
-        };
+    Stream.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.Stream) { return object }
+      var message = new $root.logproto.Stream()
+      if (object.labels != null) { message.labels = String(object.labels) }
+      if (object.entries) {
+        if (!Array.isArray(object.entries)) { throw TypeError('.logproto.Stream.entries: array expected') }
+        message.entries = []
+        for (var i = 0; i < object.entries.length; ++i) {
+          if (typeof object.entries[i] !== 'object') { throw TypeError('.logproto.Stream.entries: object expected') }
+          message.entries[i] = $root.logproto.Entry.fromObject(object.entries[i])
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a Stream message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.Stream
@@ -1909,41 +1809,35 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Stream.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.entries = [];
-            if (options.defaults)
-                object.labels = "";
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                object.labels = message.labels;
-            if (message.entries && message.entries.length) {
-                object.entries = [];
-                for (var j = 0; j < message.entries.length; ++j)
-                    object.entries[j] = $root.logproto.Entry.toObject(message.entries[j], options);
-            }
-            return object;
-        };
+    Stream.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.entries = [] }
+      if (options.defaults) { object.labels = '' }
+      if (message.labels != null && message.hasOwnProperty('labels')) { object.labels = message.labels }
+      if (message.entries && message.entries.length) {
+        object.entries = []
+        for (var j = 0; j < message.entries.length; ++j) { object.entries[j] = $root.logproto.Entry.toObject(message.entries[j], options) }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this Stream to JSON.
          * @function toJSON
          * @memberof logproto.Stream
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        Stream.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    Stream.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return Stream;
-    })();
+    return Stream
+  })()
 
-    logproto.Entry = (function() {
-
-        /**
+  logproto.Entry = (function () {
+    /**
          * Properties of an Entry.
          * @memberof logproto
          * @interface IEntry
@@ -1951,7 +1845,7 @@ $root.logproto = (function() {
          * @property {string|null} [line] Entry line
          */
 
-        /**
+    /**
          * Constructs a new Entry.
          * @memberof logproto
          * @classdesc Represents an Entry.
@@ -1959,30 +1853,31 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IEntry=} [properties] Properties to set
          */
-        function Entry(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function Entry (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * Entry timestamp.
          * @member {google.protobuf.ITimestamp|null|undefined} timestamp
          * @memberof logproto.Entry
          * @instance
          */
-        Entry.prototype.timestamp = null;
+    Entry.prototype.timestamp = null
 
-        /**
+    /**
          * Entry line.
          * @member {string} line
          * @memberof logproto.Entry
          * @instance
          */
-        Entry.prototype.line = "";
+    Entry.prototype.line = ''
 
-        /**
+    /**
          * Creates a new Entry instance using the specified properties.
          * @function create
          * @memberof logproto.Entry
@@ -1990,11 +1885,11 @@ $root.logproto = (function() {
          * @param {logproto.IEntry=} [properties] Properties to set
          * @returns {logproto.Entry} Entry instance
          */
-        Entry.create = function create(properties) {
-            return new Entry(properties);
-        };
+    Entry.create = function create (properties) {
+      return new Entry(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified Entry message. Does not implicitly {@link logproto.Entry.verify|verify} messages.
          * @function encode
          * @memberof logproto.Entry
@@ -2003,17 +1898,14 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Entry.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                $root.google.protobuf.Timestamp.encode(message.timestamp, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            if (message.line != null && message.hasOwnProperty("line"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.line);
-            return writer;
-        };
+    Entry.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.timestamp != null && message.hasOwnProperty('timestamp')) { $root.google.protobuf.Timestamp.encode(message.timestamp, writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      if (message.line != null && message.hasOwnProperty('line')) { writer.uint32(/* id 2, wireType 2 = */18).string(message.line) }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified Entry message, length delimited. Does not implicitly {@link logproto.Entry.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.Entry
@@ -2022,11 +1914,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Entry.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    Entry.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes an Entry message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.Entry
@@ -2037,28 +1929,27 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Entry.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.Entry();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.timestamp = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 2:
-                    message.line = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    Entry.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.Entry()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.timestamp = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 2:
+            message.line = reader.string()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes an Entry message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.Entry
@@ -2068,13 +1959,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Entry.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    Entry.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies an Entry message.
          * @function verify
          * @memberof logproto.Entry
@@ -2082,21 +1972,19 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        Entry.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.timestamp != null && message.hasOwnProperty("timestamp")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.timestamp);
-                if (error)
-                    return "timestamp." + error;
-            }
-            if (message.line != null && message.hasOwnProperty("line"))
-                if (!$util.isString(message.line))
-                    return "line: string expected";
-            return null;
-        };
+    Entry.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.timestamp != null && message.hasOwnProperty('timestamp')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.timestamp)
+        if (error) { return 'timestamp.' + error }
+      }
+      if (message.line != null && message.hasOwnProperty('line')) {
+        if (!$util.isString(message.line)) { return 'line: string expected' }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates an Entry message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.Entry
@@ -2104,21 +1992,18 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.Entry} Entry
          */
-        Entry.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.Entry)
-                return object;
-            var message = new $root.logproto.Entry();
-            if (object.timestamp != null) {
-                if (typeof object.timestamp !== "object")
-                    throw TypeError(".logproto.Entry.timestamp: object expected");
-                message.timestamp = $root.google.protobuf.Timestamp.fromObject(object.timestamp);
-            }
-            if (object.line != null)
-                message.line = String(object.line);
-            return message;
-        };
+    Entry.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.Entry) { return object }
+      var message = new $root.logproto.Entry()
+      if (object.timestamp != null) {
+        if (typeof object.timestamp !== 'object') { throw TypeError('.logproto.Entry.timestamp: object expected') }
+        message.timestamp = $root.google.protobuf.Timestamp.fromObject(object.timestamp)
+      }
+      if (object.line != null) { message.line = String(object.line) }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from an Entry message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.Entry
@@ -2127,38 +2012,34 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Entry.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.timestamp = null;
-                object.line = "";
-            }
-            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                object.timestamp = $root.google.protobuf.Timestamp.toObject(message.timestamp, options);
-            if (message.line != null && message.hasOwnProperty("line"))
-                object.line = message.line;
-            return object;
-        };
+    Entry.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        object.timestamp = null
+        object.line = ''
+      }
+      if (message.timestamp != null && message.hasOwnProperty('timestamp')) { object.timestamp = $root.google.protobuf.Timestamp.toObject(message.timestamp, options) }
+      if (message.line != null && message.hasOwnProperty('line')) { object.line = message.line }
+      return object
+    }
 
-        /**
+    /**
          * Converts this Entry to JSON.
          * @function toJSON
          * @memberof logproto.Entry
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        Entry.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    Entry.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return Entry;
-    })();
+    return Entry
+  })()
 
-    logproto.TailRequest = (function() {
-
-        /**
+  logproto.TailRequest = (function () {
+    /**
          * Properties of a TailRequest.
          * @memberof logproto
          * @interface ITailRequest
@@ -2168,7 +2049,7 @@ $root.logproto = (function() {
          * @property {google.protobuf.ITimestamp|null} [start] TailRequest start
          */
 
-        /**
+    /**
          * Constructs a new TailRequest.
          * @memberof logproto
          * @classdesc Represents a TailRequest.
@@ -2176,46 +2057,47 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ITailRequest=} [properties] Properties to set
          */
-        function TailRequest(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function TailRequest (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * TailRequest query.
          * @member {string} query
          * @memberof logproto.TailRequest
          * @instance
          */
-        TailRequest.prototype.query = "";
+    TailRequest.prototype.query = ''
 
-        /**
+    /**
          * TailRequest delayFor.
          * @member {number} delayFor
          * @memberof logproto.TailRequest
          * @instance
          */
-        TailRequest.prototype.delayFor = 0;
+    TailRequest.prototype.delayFor = 0
 
-        /**
+    /**
          * TailRequest limit.
          * @member {number} limit
          * @memberof logproto.TailRequest
          * @instance
          */
-        TailRequest.prototype.limit = 0;
+    TailRequest.prototype.limit = 0
 
-        /**
+    /**
          * TailRequest start.
          * @member {google.protobuf.ITimestamp|null|undefined} start
          * @memberof logproto.TailRequest
          * @instance
          */
-        TailRequest.prototype.start = null;
+    TailRequest.prototype.start = null
 
-        /**
+    /**
          * Creates a new TailRequest instance using the specified properties.
          * @function create
          * @memberof logproto.TailRequest
@@ -2223,11 +2105,11 @@ $root.logproto = (function() {
          * @param {logproto.ITailRequest=} [properties] Properties to set
          * @returns {logproto.TailRequest} TailRequest instance
          */
-        TailRequest.create = function create(properties) {
-            return new TailRequest(properties);
-        };
+    TailRequest.create = function create (properties) {
+      return new TailRequest(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified TailRequest message. Does not implicitly {@link logproto.TailRequest.verify|verify} messages.
          * @function encode
          * @memberof logproto.TailRequest
@@ -2236,21 +2118,16 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.query != null && message.hasOwnProperty("query"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.query);
-            if (message.delayFor != null && message.hasOwnProperty("delayFor"))
-                writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.delayFor);
-            if (message.limit != null && message.hasOwnProperty("limit"))
-                writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.limit);
-            if (message.start != null && message.hasOwnProperty("start"))
-                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-            return writer;
-        };
+    TailRequest.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.query != null && message.hasOwnProperty('query')) { writer.uint32(/* id 1, wireType 2 = */10).string(message.query) }
+      if (message.delayFor != null && message.hasOwnProperty('delayFor')) { writer.uint32(/* id 3, wireType 0 = */24).uint32(message.delayFor) }
+      if (message.limit != null && message.hasOwnProperty('limit')) { writer.uint32(/* id 4, wireType 0 = */32).uint32(message.limit) }
+      if (message.start != null && message.hasOwnProperty('start')) { $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 5, wireType 2 = */42).fork()).ldelim() }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified TailRequest message, length delimited. Does not implicitly {@link logproto.TailRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.TailRequest
@@ -2259,11 +2136,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    TailRequest.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a TailRequest message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.TailRequest
@@ -2274,34 +2151,33 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.query = reader.string();
-                    break;
-                case 3:
-                    message.delayFor = reader.uint32();
-                    break;
-                case 4:
-                    message.limit = reader.uint32();
-                    break;
-                case 5:
-                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    TailRequest.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.TailRequest()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.query = reader.string()
+            break
+          case 3:
+            message.delayFor = reader.uint32()
+            break
+          case 4:
+            message.limit = reader.uint32()
+            break
+          case 5:
+            message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a TailRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.TailRequest
@@ -2311,13 +2187,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    TailRequest.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a TailRequest message.
          * @function verify
          * @memberof logproto.TailRequest
@@ -2325,27 +2200,25 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        TailRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.query != null && message.hasOwnProperty("query"))
-                if (!$util.isString(message.query))
-                    return "query: string expected";
-            if (message.delayFor != null && message.hasOwnProperty("delayFor"))
-                if (!$util.isInteger(message.delayFor))
-                    return "delayFor: integer expected";
-            if (message.limit != null && message.hasOwnProperty("limit"))
-                if (!$util.isInteger(message.limit))
-                    return "limit: integer expected";
-            if (message.start != null && message.hasOwnProperty("start")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.start);
-                if (error)
-                    return "start." + error;
-            }
-            return null;
-        };
+    TailRequest.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.query != null && message.hasOwnProperty('query')) {
+        if (!$util.isString(message.query)) { return 'query: string expected' }
+      }
+      if (message.delayFor != null && message.hasOwnProperty('delayFor')) {
+        if (!$util.isInteger(message.delayFor)) { return 'delayFor: integer expected' }
+      }
+      if (message.limit != null && message.hasOwnProperty('limit')) {
+        if (!$util.isInteger(message.limit)) { return 'limit: integer expected' }
+      }
+      if (message.start != null && message.hasOwnProperty('start')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.start)
+        if (error) { return 'start.' + error }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a TailRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.TailRequest
@@ -2353,25 +2226,20 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.TailRequest} TailRequest
          */
-        TailRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.TailRequest)
-                return object;
-            var message = new $root.logproto.TailRequest();
-            if (object.query != null)
-                message.query = String(object.query);
-            if (object.delayFor != null)
-                message.delayFor = object.delayFor >>> 0;
-            if (object.limit != null)
-                message.limit = object.limit >>> 0;
-            if (object.start != null) {
-                if (typeof object.start !== "object")
-                    throw TypeError(".logproto.TailRequest.start: object expected");
-                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
-            }
-            return message;
-        };
+    TailRequest.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.TailRequest) { return object }
+      var message = new $root.logproto.TailRequest()
+      if (object.query != null) { message.query = String(object.query) }
+      if (object.delayFor != null) { message.delayFor = object.delayFor >>> 0 }
+      if (object.limit != null) { message.limit = object.limit >>> 0 }
+      if (object.start != null) {
+        if (typeof object.start !== 'object') { throw TypeError('.logproto.TailRequest.start: object expected') }
+        message.start = $root.google.protobuf.Timestamp.fromObject(object.start)
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a TailRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.TailRequest
@@ -2380,44 +2248,38 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        TailRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.query = "";
-                object.delayFor = 0;
-                object.limit = 0;
-                object.start = null;
-            }
-            if (message.query != null && message.hasOwnProperty("query"))
-                object.query = message.query;
-            if (message.delayFor != null && message.hasOwnProperty("delayFor"))
-                object.delayFor = message.delayFor;
-            if (message.limit != null && message.hasOwnProperty("limit"))
-                object.limit = message.limit;
-            if (message.start != null && message.hasOwnProperty("start"))
-                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
-            return object;
-        };
+    TailRequest.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        object.query = ''
+        object.delayFor = 0
+        object.limit = 0
+        object.start = null
+      }
+      if (message.query != null && message.hasOwnProperty('query')) { object.query = message.query }
+      if (message.delayFor != null && message.hasOwnProperty('delayFor')) { object.delayFor = message.delayFor }
+      if (message.limit != null && message.hasOwnProperty('limit')) { object.limit = message.limit }
+      if (message.start != null && message.hasOwnProperty('start')) { object.start = $root.google.protobuf.Timestamp.toObject(message.start, options) }
+      return object
+    }
 
-        /**
+    /**
          * Converts this TailRequest to JSON.
          * @function toJSON
          * @memberof logproto.TailRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        TailRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    TailRequest.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return TailRequest;
-    })();
+    return TailRequest
+  })()
 
-    logproto.TailResponse = (function() {
-
-        /**
+  logproto.TailResponse = (function () {
+    /**
          * Properties of a TailResponse.
          * @memberof logproto
          * @interface ITailResponse
@@ -2425,7 +2287,7 @@ $root.logproto = (function() {
          * @property {Array.<logproto.IDroppedStream>|null} [droppedStreams] TailResponse droppedStreams
          */
 
-        /**
+    /**
          * Constructs a new TailResponse.
          * @memberof logproto
          * @classdesc Represents a TailResponse.
@@ -2433,31 +2295,32 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ITailResponse=} [properties] Properties to set
          */
-        function TailResponse(properties) {
-            this.droppedStreams = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function TailResponse (properties) {
+      this.droppedStreams = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * TailResponse stream.
          * @member {logproto.IStream|null|undefined} stream
          * @memberof logproto.TailResponse
          * @instance
          */
-        TailResponse.prototype.stream = null;
+    TailResponse.prototype.stream = null
 
-        /**
+    /**
          * TailResponse droppedStreams.
          * @member {Array.<logproto.IDroppedStream>} droppedStreams
          * @memberof logproto.TailResponse
          * @instance
          */
-        TailResponse.prototype.droppedStreams = $util.emptyArray;
+    TailResponse.prototype.droppedStreams = $util.emptyArray
 
-        /**
+    /**
          * Creates a new TailResponse instance using the specified properties.
          * @function create
          * @memberof logproto.TailResponse
@@ -2465,11 +2328,11 @@ $root.logproto = (function() {
          * @param {logproto.ITailResponse=} [properties] Properties to set
          * @returns {logproto.TailResponse} TailResponse instance
          */
-        TailResponse.create = function create(properties) {
-            return new TailResponse(properties);
-        };
+    TailResponse.create = function create (properties) {
+      return new TailResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified TailResponse message. Does not implicitly {@link logproto.TailResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.TailResponse
@@ -2478,18 +2341,16 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                $root.logproto.Stream.encode(message.stream, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            if (message.droppedStreams != null && message.droppedStreams.length)
-                for (var i = 0; i < message.droppedStreams.length; ++i)
-                    $root.logproto.DroppedStream.encode(message.droppedStreams[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-            return writer;
-        };
+    TailResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.stream != null && message.hasOwnProperty('stream')) { $root.logproto.Stream.encode(message.stream, writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      if (message.droppedStreams != null && message.droppedStreams.length) {
+        for (var i = 0; i < message.droppedStreams.length; ++i) { $root.logproto.DroppedStream.encode(message.droppedStreams[i], writer.uint32(/* id 2, wireType 2 = */18).fork()).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified TailResponse message, length delimited. Does not implicitly {@link logproto.TailResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.TailResponse
@@ -2498,11 +2359,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    TailResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a TailResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.TailResponse
@@ -2513,30 +2374,28 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.stream = $root.logproto.Stream.decode(reader, reader.uint32());
-                    break;
-                case 2:
-                    if (!(message.droppedStreams && message.droppedStreams.length))
-                        message.droppedStreams = [];
-                    message.droppedStreams.push($root.logproto.DroppedStream.decode(reader, reader.uint32()));
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    TailResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.TailResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.stream = $root.logproto.Stream.decode(reader, reader.uint32())
+            break
+          case 2:
+            if (!(message.droppedStreams && message.droppedStreams.length)) { message.droppedStreams = [] }
+            message.droppedStreams.push($root.logproto.DroppedStream.decode(reader, reader.uint32()))
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a TailResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.TailResponse
@@ -2546,13 +2405,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    TailResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a TailResponse message.
          * @function verify
          * @memberof logproto.TailResponse
@@ -2560,27 +2418,23 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        TailResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.stream != null && message.hasOwnProperty("stream")) {
-                var error = $root.logproto.Stream.verify(message.stream);
-                if (error)
-                    return "stream." + error;
-            }
-            if (message.droppedStreams != null && message.hasOwnProperty("droppedStreams")) {
-                if (!Array.isArray(message.droppedStreams))
-                    return "droppedStreams: array expected";
-                for (var i = 0; i < message.droppedStreams.length; ++i) {
-                    var error = $root.logproto.DroppedStream.verify(message.droppedStreams[i]);
-                    if (error)
-                        return "droppedStreams." + error;
-                }
-            }
-            return null;
-        };
+    TailResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.stream != null && message.hasOwnProperty('stream')) {
+        var error = $root.logproto.Stream.verify(message.stream)
+        if (error) { return 'stream.' + error }
+      }
+      if (message.droppedStreams != null && message.hasOwnProperty('droppedStreams')) {
+        if (!Array.isArray(message.droppedStreams)) { return 'droppedStreams: array expected' }
+        for (var i = 0; i < message.droppedStreams.length; ++i) {
+          var error = $root.logproto.DroppedStream.verify(message.droppedStreams[i])
+          if (error) { return 'droppedStreams.' + error }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a TailResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.TailResponse
@@ -2588,29 +2442,25 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.TailResponse} TailResponse
          */
-        TailResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.TailResponse)
-                return object;
-            var message = new $root.logproto.TailResponse();
-            if (object.stream != null) {
-                if (typeof object.stream !== "object")
-                    throw TypeError(".logproto.TailResponse.stream: object expected");
-                message.stream = $root.logproto.Stream.fromObject(object.stream);
-            }
-            if (object.droppedStreams) {
-                if (!Array.isArray(object.droppedStreams))
-                    throw TypeError(".logproto.TailResponse.droppedStreams: array expected");
-                message.droppedStreams = [];
-                for (var i = 0; i < object.droppedStreams.length; ++i) {
-                    if (typeof object.droppedStreams[i] !== "object")
-                        throw TypeError(".logproto.TailResponse.droppedStreams: object expected");
-                    message.droppedStreams[i] = $root.logproto.DroppedStream.fromObject(object.droppedStreams[i]);
-                }
-            }
-            return message;
-        };
+    TailResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.TailResponse) { return object }
+      var message = new $root.logproto.TailResponse()
+      if (object.stream != null) {
+        if (typeof object.stream !== 'object') { throw TypeError('.logproto.TailResponse.stream: object expected') }
+        message.stream = $root.logproto.Stream.fromObject(object.stream)
+      }
+      if (object.droppedStreams) {
+        if (!Array.isArray(object.droppedStreams)) { throw TypeError('.logproto.TailResponse.droppedStreams: array expected') }
+        message.droppedStreams = []
+        for (var i = 0; i < object.droppedStreams.length; ++i) {
+          if (typeof object.droppedStreams[i] !== 'object') { throw TypeError('.logproto.TailResponse.droppedStreams: object expected') }
+          message.droppedStreams[i] = $root.logproto.DroppedStream.fromObject(object.droppedStreams[i])
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a TailResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.TailResponse
@@ -2619,41 +2469,35 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        TailResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.droppedStreams = [];
-            if (options.defaults)
-                object.stream = null;
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                object.stream = $root.logproto.Stream.toObject(message.stream, options);
-            if (message.droppedStreams && message.droppedStreams.length) {
-                object.droppedStreams = [];
-                for (var j = 0; j < message.droppedStreams.length; ++j)
-                    object.droppedStreams[j] = $root.logproto.DroppedStream.toObject(message.droppedStreams[j], options);
-            }
-            return object;
-        };
+    TailResponse.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.droppedStreams = [] }
+      if (options.defaults) { object.stream = null }
+      if (message.stream != null && message.hasOwnProperty('stream')) { object.stream = $root.logproto.Stream.toObject(message.stream, options) }
+      if (message.droppedStreams && message.droppedStreams.length) {
+        object.droppedStreams = []
+        for (var j = 0; j < message.droppedStreams.length; ++j) { object.droppedStreams[j] = $root.logproto.DroppedStream.toObject(message.droppedStreams[j], options) }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this TailResponse to JSON.
          * @function toJSON
          * @memberof logproto.TailResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        TailResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    TailResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return TailResponse;
-    })();
+    return TailResponse
+  })()
 
-    logproto.SeriesRequest = (function() {
-
-        /**
+  logproto.SeriesRequest = (function () {
+    /**
          * Properties of a SeriesRequest.
          * @memberof logproto
          * @interface ISeriesRequest
@@ -2662,7 +2506,7 @@ $root.logproto = (function() {
          * @property {Array.<string>|null} [groups] SeriesRequest groups
          */
 
-        /**
+    /**
          * Constructs a new SeriesRequest.
          * @memberof logproto
          * @classdesc Represents a SeriesRequest.
@@ -2670,39 +2514,40 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ISeriesRequest=} [properties] Properties to set
          */
-        function SeriesRequest(properties) {
-            this.groups = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function SeriesRequest (properties) {
+      this.groups = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * SeriesRequest start.
          * @member {google.protobuf.ITimestamp|null|undefined} start
          * @memberof logproto.SeriesRequest
          * @instance
          */
-        SeriesRequest.prototype.start = null;
+    SeriesRequest.prototype.start = null
 
-        /**
+    /**
          * SeriesRequest end.
          * @member {google.protobuf.ITimestamp|null|undefined} end
          * @memberof logproto.SeriesRequest
          * @instance
          */
-        SeriesRequest.prototype.end = null;
+    SeriesRequest.prototype.end = null
 
-        /**
+    /**
          * SeriesRequest groups.
          * @member {Array.<string>} groups
          * @memberof logproto.SeriesRequest
          * @instance
          */
-        SeriesRequest.prototype.groups = $util.emptyArray;
+    SeriesRequest.prototype.groups = $util.emptyArray
 
-        /**
+    /**
          * Creates a new SeriesRequest instance using the specified properties.
          * @function create
          * @memberof logproto.SeriesRequest
@@ -2710,11 +2555,11 @@ $root.logproto = (function() {
          * @param {logproto.ISeriesRequest=} [properties] Properties to set
          * @returns {logproto.SeriesRequest} SeriesRequest instance
          */
-        SeriesRequest.create = function create(properties) {
-            return new SeriesRequest(properties);
-        };
+    SeriesRequest.create = function create (properties) {
+      return new SeriesRequest(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified SeriesRequest message. Does not implicitly {@link logproto.SeriesRequest.verify|verify} messages.
          * @function encode
          * @memberof logproto.SeriesRequest
@@ -2723,20 +2568,17 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        SeriesRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.start != null && message.hasOwnProperty("start"))
-                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            if (message.end != null && message.hasOwnProperty("end"))
-                $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-            if (message.groups != null && message.groups.length)
-                for (var i = 0; i < message.groups.length; ++i)
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.groups[i]);
-            return writer;
-        };
+    SeriesRequest.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.start != null && message.hasOwnProperty('start')) { $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      if (message.end != null && message.hasOwnProperty('end')) { $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 2, wireType 2 = */18).fork()).ldelim() }
+      if (message.groups != null && message.groups.length) {
+        for (var i = 0; i < message.groups.length; ++i) { writer.uint32(/* id 3, wireType 2 = */26).string(message.groups[i]) }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified SeriesRequest message, length delimited. Does not implicitly {@link logproto.SeriesRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.SeriesRequest
@@ -2745,11 +2587,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        SeriesRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    SeriesRequest.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a SeriesRequest message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.SeriesRequest
@@ -2760,33 +2602,31 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        SeriesRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.SeriesRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 2:
-                    message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 3:
-                    if (!(message.groups && message.groups.length))
-                        message.groups = [];
-                    message.groups.push(reader.string());
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    SeriesRequest.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.SeriesRequest()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 2:
+            message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 3:
+            if (!(message.groups && message.groups.length)) { message.groups = [] }
+            message.groups.push(reader.string())
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a SeriesRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.SeriesRequest
@@ -2796,13 +2636,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        SeriesRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    SeriesRequest.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a SeriesRequest message.
          * @function verify
          * @memberof logproto.SeriesRequest
@@ -2810,30 +2649,26 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        SeriesRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.start != null && message.hasOwnProperty("start")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.start);
-                if (error)
-                    return "start." + error;
-            }
-            if (message.end != null && message.hasOwnProperty("end")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.end);
-                if (error)
-                    return "end." + error;
-            }
-            if (message.groups != null && message.hasOwnProperty("groups")) {
-                if (!Array.isArray(message.groups))
-                    return "groups: array expected";
-                for (var i = 0; i < message.groups.length; ++i)
-                    if (!$util.isString(message.groups[i]))
-                        return "groups: string[] expected";
-            }
-            return null;
-        };
+    SeriesRequest.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.start != null && message.hasOwnProperty('start')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.start)
+        if (error) { return 'start.' + error }
+      }
+      if (message.end != null && message.hasOwnProperty('end')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.end)
+        if (error) { return 'end.' + error }
+      }
+      if (message.groups != null && message.hasOwnProperty('groups')) {
+        if (!Array.isArray(message.groups)) { return 'groups: array expected' }
+        for (var i = 0; i < message.groups.length; ++i) {
+          if (!$util.isString(message.groups[i])) { return 'groups: string[] expected' }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a SeriesRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.SeriesRequest
@@ -2841,31 +2676,26 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.SeriesRequest} SeriesRequest
          */
-        SeriesRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.SeriesRequest)
-                return object;
-            var message = new $root.logproto.SeriesRequest();
-            if (object.start != null) {
-                if (typeof object.start !== "object")
-                    throw TypeError(".logproto.SeriesRequest.start: object expected");
-                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
-            }
-            if (object.end != null) {
-                if (typeof object.end !== "object")
-                    throw TypeError(".logproto.SeriesRequest.end: object expected");
-                message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
-            }
-            if (object.groups) {
-                if (!Array.isArray(object.groups))
-                    throw TypeError(".logproto.SeriesRequest.groups: array expected");
-                message.groups = [];
-                for (var i = 0; i < object.groups.length; ++i)
-                    message.groups[i] = String(object.groups[i]);
-            }
-            return message;
-        };
+    SeriesRequest.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.SeriesRequest) { return object }
+      var message = new $root.logproto.SeriesRequest()
+      if (object.start != null) {
+        if (typeof object.start !== 'object') { throw TypeError('.logproto.SeriesRequest.start: object expected') }
+        message.start = $root.google.protobuf.Timestamp.fromObject(object.start)
+      }
+      if (object.end != null) {
+        if (typeof object.end !== 'object') { throw TypeError('.logproto.SeriesRequest.end: object expected') }
+        message.end = $root.google.protobuf.Timestamp.fromObject(object.end)
+      }
+      if (object.groups) {
+        if (!Array.isArray(object.groups)) { throw TypeError('.logproto.SeriesRequest.groups: array expected') }
+        message.groups = []
+        for (var i = 0; i < object.groups.length; ++i) { message.groups[i] = String(object.groups[i]) }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a SeriesRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.SeriesRequest
@@ -2874,52 +2704,46 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        SeriesRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.groups = [];
-            if (options.defaults) {
-                object.start = null;
-                object.end = null;
-            }
-            if (message.start != null && message.hasOwnProperty("start"))
-                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
-            if (message.end != null && message.hasOwnProperty("end"))
-                object.end = $root.google.protobuf.Timestamp.toObject(message.end, options);
-            if (message.groups && message.groups.length) {
-                object.groups = [];
-                for (var j = 0; j < message.groups.length; ++j)
-                    object.groups[j] = message.groups[j];
-            }
-            return object;
-        };
+    SeriesRequest.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.groups = [] }
+      if (options.defaults) {
+        object.start = null
+        object.end = null
+      }
+      if (message.start != null && message.hasOwnProperty('start')) { object.start = $root.google.protobuf.Timestamp.toObject(message.start, options) }
+      if (message.end != null && message.hasOwnProperty('end')) { object.end = $root.google.protobuf.Timestamp.toObject(message.end, options) }
+      if (message.groups && message.groups.length) {
+        object.groups = []
+        for (var j = 0; j < message.groups.length; ++j) { object.groups[j] = message.groups[j] }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this SeriesRequest to JSON.
          * @function toJSON
          * @memberof logproto.SeriesRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        SeriesRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    SeriesRequest.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return SeriesRequest;
-    })();
+    return SeriesRequest
+  })()
 
-    logproto.SeriesResponse = (function() {
-
-        /**
+  logproto.SeriesResponse = (function () {
+    /**
          * Properties of a SeriesResponse.
          * @memberof logproto
          * @interface ISeriesResponse
          * @property {Array.<logproto.ISeriesIdentifier>|null} [series] SeriesResponse series
          */
 
-        /**
+    /**
          * Constructs a new SeriesResponse.
          * @memberof logproto
          * @classdesc Represents a SeriesResponse.
@@ -2927,23 +2751,24 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ISeriesResponse=} [properties] Properties to set
          */
-        function SeriesResponse(properties) {
-            this.series = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function SeriesResponse (properties) {
+      this.series = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * SeriesResponse series.
          * @member {Array.<logproto.ISeriesIdentifier>} series
          * @memberof logproto.SeriesResponse
          * @instance
          */
-        SeriesResponse.prototype.series = $util.emptyArray;
+    SeriesResponse.prototype.series = $util.emptyArray
 
-        /**
+    /**
          * Creates a new SeriesResponse instance using the specified properties.
          * @function create
          * @memberof logproto.SeriesResponse
@@ -2951,11 +2776,11 @@ $root.logproto = (function() {
          * @param {logproto.ISeriesResponse=} [properties] Properties to set
          * @returns {logproto.SeriesResponse} SeriesResponse instance
          */
-        SeriesResponse.create = function create(properties) {
-            return new SeriesResponse(properties);
-        };
+    SeriesResponse.create = function create (properties) {
+      return new SeriesResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified SeriesResponse message. Does not implicitly {@link logproto.SeriesResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.SeriesResponse
@@ -2964,16 +2789,15 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        SeriesResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.series != null && message.series.length)
-                for (var i = 0; i < message.series.length; ++i)
-                    $root.logproto.SeriesIdentifier.encode(message.series[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            return writer;
-        };
+    SeriesResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.series != null && message.series.length) {
+        for (var i = 0; i < message.series.length; ++i) { $root.logproto.SeriesIdentifier.encode(message.series[i], writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified SeriesResponse message, length delimited. Does not implicitly {@link logproto.SeriesResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.SeriesResponse
@@ -2982,11 +2806,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        SeriesResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    SeriesResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a SeriesResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.SeriesResponse
@@ -2997,27 +2821,25 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        SeriesResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.SeriesResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    if (!(message.series && message.series.length))
-                        message.series = [];
-                    message.series.push($root.logproto.SeriesIdentifier.decode(reader, reader.uint32()));
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    SeriesResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.SeriesResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            if (!(message.series && message.series.length)) { message.series = [] }
+            message.series.push($root.logproto.SeriesIdentifier.decode(reader, reader.uint32()))
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a SeriesResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.SeriesResponse
@@ -3027,13 +2849,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        SeriesResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    SeriesResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a SeriesResponse message.
          * @function verify
          * @memberof logproto.SeriesResponse
@@ -3041,22 +2862,19 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        SeriesResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.series != null && message.hasOwnProperty("series")) {
-                if (!Array.isArray(message.series))
-                    return "series: array expected";
-                for (var i = 0; i < message.series.length; ++i) {
-                    var error = $root.logproto.SeriesIdentifier.verify(message.series[i]);
-                    if (error)
-                        return "series." + error;
-                }
-            }
-            return null;
-        };
+    SeriesResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.series != null && message.hasOwnProperty('series')) {
+        if (!Array.isArray(message.series)) { return 'series: array expected' }
+        for (var i = 0; i < message.series.length; ++i) {
+          var error = $root.logproto.SeriesIdentifier.verify(message.series[i])
+          if (error) { return 'series.' + error }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a SeriesResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.SeriesResponse
@@ -3064,24 +2882,21 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.SeriesResponse} SeriesResponse
          */
-        SeriesResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.SeriesResponse)
-                return object;
-            var message = new $root.logproto.SeriesResponse();
-            if (object.series) {
-                if (!Array.isArray(object.series))
-                    throw TypeError(".logproto.SeriesResponse.series: array expected");
-                message.series = [];
-                for (var i = 0; i < object.series.length; ++i) {
-                    if (typeof object.series[i] !== "object")
-                        throw TypeError(".logproto.SeriesResponse.series: object expected");
-                    message.series[i] = $root.logproto.SeriesIdentifier.fromObject(object.series[i]);
-                }
-            }
-            return message;
-        };
+    SeriesResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.SeriesResponse) { return object }
+      var message = new $root.logproto.SeriesResponse()
+      if (object.series) {
+        if (!Array.isArray(object.series)) { throw TypeError('.logproto.SeriesResponse.series: array expected') }
+        message.series = []
+        for (var i = 0; i < object.series.length; ++i) {
+          if (typeof object.series[i] !== 'object') { throw TypeError('.logproto.SeriesResponse.series: object expected') }
+          message.series[i] = $root.logproto.SeriesIdentifier.fromObject(object.series[i])
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a SeriesResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.SeriesResponse
@@ -3090,44 +2905,40 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        SeriesResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.series = [];
-            if (message.series && message.series.length) {
-                object.series = [];
-                for (var j = 0; j < message.series.length; ++j)
-                    object.series[j] = $root.logproto.SeriesIdentifier.toObject(message.series[j], options);
-            }
-            return object;
-        };
+    SeriesResponse.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) { object.series = [] }
+      if (message.series && message.series.length) {
+        object.series = []
+        for (var j = 0; j < message.series.length; ++j) { object.series[j] = $root.logproto.SeriesIdentifier.toObject(message.series[j], options) }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this SeriesResponse to JSON.
          * @function toJSON
          * @memberof logproto.SeriesResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        SeriesResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    SeriesResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return SeriesResponse;
-    })();
+    return SeriesResponse
+  })()
 
-    logproto.SeriesIdentifier = (function() {
-
-        /**
+  logproto.SeriesIdentifier = (function () {
+    /**
          * Properties of a SeriesIdentifier.
          * @memberof logproto
          * @interface ISeriesIdentifier
          * @property {Object.<string,string>|null} [labels] SeriesIdentifier labels
          */
 
-        /**
+    /**
          * Constructs a new SeriesIdentifier.
          * @memberof logproto
          * @classdesc Represents a SeriesIdentifier.
@@ -3135,23 +2946,24 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ISeriesIdentifier=} [properties] Properties to set
          */
-        function SeriesIdentifier(properties) {
-            this.labels = {};
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function SeriesIdentifier (properties) {
+      this.labels = {}
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * SeriesIdentifier labels.
          * @member {Object.<string,string>} labels
          * @memberof logproto.SeriesIdentifier
          * @instance
          */
-        SeriesIdentifier.prototype.labels = $util.emptyObject;
+    SeriesIdentifier.prototype.labels = $util.emptyObject
 
-        /**
+    /**
          * Creates a new SeriesIdentifier instance using the specified properties.
          * @function create
          * @memberof logproto.SeriesIdentifier
@@ -3159,11 +2971,11 @@ $root.logproto = (function() {
          * @param {logproto.ISeriesIdentifier=} [properties] Properties to set
          * @returns {logproto.SeriesIdentifier} SeriesIdentifier instance
          */
-        SeriesIdentifier.create = function create(properties) {
-            return new SeriesIdentifier(properties);
-        };
+    SeriesIdentifier.create = function create (properties) {
+      return new SeriesIdentifier(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified SeriesIdentifier message. Does not implicitly {@link logproto.SeriesIdentifier.verify|verify} messages.
          * @function encode
          * @memberof logproto.SeriesIdentifier
@@ -3172,16 +2984,15 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        SeriesIdentifier.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                for (var keys = Object.keys(message.labels), i = 0; i < keys.length; ++i)
-                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.labels[keys[i]]).ldelim();
-            return writer;
-        };
+    SeriesIdentifier.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.labels != null && message.hasOwnProperty('labels')) {
+        for (var keys = Object.keys(message.labels), i = 0; i < keys.length; ++i) { writer.uint32(/* id 1, wireType 2 = */10).fork().uint32(/* id 1, wireType 2 = */10).string(keys[i]).uint32(/* id 2, wireType 2 = */18).string(message.labels[keys[i]]).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified SeriesIdentifier message, length delimited. Does not implicitly {@link logproto.SeriesIdentifier.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.SeriesIdentifier
@@ -3190,11 +3001,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        SeriesIdentifier.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    SeriesIdentifier.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a SeriesIdentifier message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.SeriesIdentifier
@@ -3205,30 +3016,28 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        SeriesIdentifier.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.SeriesIdentifier(), key;
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    reader.skip().pos++;
-                    if (message.labels === $util.emptyObject)
-                        message.labels = {};
-                    key = reader.string();
-                    reader.pos++;
-                    message.labels[key] = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    SeriesIdentifier.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.SeriesIdentifier(); var key
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            reader.skip().pos++
+            if (message.labels === $util.emptyObject) { message.labels = {} }
+            key = reader.string()
+            reader.pos++
+            message.labels[key] = reader.string()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a SeriesIdentifier message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.SeriesIdentifier
@@ -3238,13 +3047,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        SeriesIdentifier.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    SeriesIdentifier.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a SeriesIdentifier message.
          * @function verify
          * @memberof logproto.SeriesIdentifier
@@ -3252,21 +3060,19 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        SeriesIdentifier.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.labels != null && message.hasOwnProperty("labels")) {
-                if (!$util.isObject(message.labels))
-                    return "labels: object expected";
-                var key = Object.keys(message.labels);
-                for (var i = 0; i < key.length; ++i)
-                    if (!$util.isString(message.labels[key[i]]))
-                        return "labels: string{k:string} expected";
-            }
-            return null;
-        };
+    SeriesIdentifier.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.labels != null && message.hasOwnProperty('labels')) {
+        if (!$util.isObject(message.labels)) { return 'labels: object expected' }
+        var key = Object.keys(message.labels)
+        for (var i = 0; i < key.length; ++i) {
+          if (!$util.isString(message.labels[key[i]])) { return 'labels: string{k:string} expected' }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a SeriesIdentifier message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.SeriesIdentifier
@@ -3274,21 +3080,18 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.SeriesIdentifier} SeriesIdentifier
          */
-        SeriesIdentifier.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.SeriesIdentifier)
-                return object;
-            var message = new $root.logproto.SeriesIdentifier();
-            if (object.labels) {
-                if (typeof object.labels !== "object")
-                    throw TypeError(".logproto.SeriesIdentifier.labels: object expected");
-                message.labels = {};
-                for (var keys = Object.keys(object.labels), i = 0; i < keys.length; ++i)
-                    message.labels[keys[i]] = String(object.labels[keys[i]]);
-            }
-            return message;
-        };
+    SeriesIdentifier.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.SeriesIdentifier) { return object }
+      var message = new $root.logproto.SeriesIdentifier()
+      if (object.labels) {
+        if (typeof object.labels !== 'object') { throw TypeError('.logproto.SeriesIdentifier.labels: object expected') }
+        message.labels = {}
+        for (var keys = Object.keys(object.labels), i = 0; i < keys.length; ++i) { message.labels[keys[i]] = String(object.labels[keys[i]]) }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a SeriesIdentifier message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.SeriesIdentifier
@@ -3297,38 +3100,34 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        SeriesIdentifier.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.objects || options.defaults)
-                object.labels = {};
-            var keys2;
-            if (message.labels && (keys2 = Object.keys(message.labels)).length) {
-                object.labels = {};
-                for (var j = 0; j < keys2.length; ++j)
-                    object.labels[keys2[j]] = message.labels[keys2[j]];
-            }
-            return object;
-        };
+    SeriesIdentifier.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.objects || options.defaults) { object.labels = {} }
+      var keys2
+      if (message.labels && (keys2 = Object.keys(message.labels)).length) {
+        object.labels = {}
+        for (var j = 0; j < keys2.length; ++j) { object.labels[keys2[j]] = message.labels[keys2[j]] }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this SeriesIdentifier to JSON.
          * @function toJSON
          * @memberof logproto.SeriesIdentifier
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        SeriesIdentifier.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    SeriesIdentifier.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return SeriesIdentifier;
-    })();
+    return SeriesIdentifier
+  })()
 
-    logproto.DroppedStream = (function() {
-
-        /**
+  logproto.DroppedStream = (function () {
+    /**
          * Properties of a DroppedStream.
          * @memberof logproto
          * @interface IDroppedStream
@@ -3337,7 +3136,7 @@ $root.logproto = (function() {
          * @property {string|null} [labels] DroppedStream labels
          */
 
-        /**
+    /**
          * Constructs a new DroppedStream.
          * @memberof logproto
          * @classdesc Represents a DroppedStream.
@@ -3345,38 +3144,39 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IDroppedStream=} [properties] Properties to set
          */
-        function DroppedStream(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function DroppedStream (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * DroppedStream from.
          * @member {google.protobuf.ITimestamp|null|undefined} from
          * @memberof logproto.DroppedStream
          * @instance
          */
-        DroppedStream.prototype.from = null;
+    DroppedStream.prototype.from = null
 
-        /**
+    /**
          * DroppedStream to.
          * @member {google.protobuf.ITimestamp|null|undefined} to
          * @memberof logproto.DroppedStream
          * @instance
          */
-        DroppedStream.prototype.to = null;
+    DroppedStream.prototype.to = null
 
-        /**
+    /**
          * DroppedStream labels.
          * @member {string} labels
          * @memberof logproto.DroppedStream
          * @instance
          */
-        DroppedStream.prototype.labels = "";
+    DroppedStream.prototype.labels = ''
 
-        /**
+    /**
          * Creates a new DroppedStream instance using the specified properties.
          * @function create
          * @memberof logproto.DroppedStream
@@ -3384,11 +3184,11 @@ $root.logproto = (function() {
          * @param {logproto.IDroppedStream=} [properties] Properties to set
          * @returns {logproto.DroppedStream} DroppedStream instance
          */
-        DroppedStream.create = function create(properties) {
-            return new DroppedStream(properties);
-        };
+    DroppedStream.create = function create (properties) {
+      return new DroppedStream(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified DroppedStream message. Does not implicitly {@link logproto.DroppedStream.verify|verify} messages.
          * @function encode
          * @memberof logproto.DroppedStream
@@ -3397,19 +3197,15 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        DroppedStream.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.from != null && message.hasOwnProperty("from"))
-                $root.google.protobuf.Timestamp.encode(message.from, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            if (message.to != null && message.hasOwnProperty("to"))
-                $root.google.protobuf.Timestamp.encode(message.to, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.labels);
-            return writer;
-        };
+    DroppedStream.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.from != null && message.hasOwnProperty('from')) { $root.google.protobuf.Timestamp.encode(message.from, writer.uint32(/* id 1, wireType 2 = */10).fork()).ldelim() }
+      if (message.to != null && message.hasOwnProperty('to')) { $root.google.protobuf.Timestamp.encode(message.to, writer.uint32(/* id 2, wireType 2 = */18).fork()).ldelim() }
+      if (message.labels != null && message.hasOwnProperty('labels')) { writer.uint32(/* id 3, wireType 2 = */26).string(message.labels) }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified DroppedStream message, length delimited. Does not implicitly {@link logproto.DroppedStream.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.DroppedStream
@@ -3418,11 +3214,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        DroppedStream.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    DroppedStream.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a DroppedStream message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.DroppedStream
@@ -3433,31 +3229,30 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        DroppedStream.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.DroppedStream();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.from = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 2:
-                    message.to = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
-                    break;
-                case 3:
-                    message.labels = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    DroppedStream.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.DroppedStream()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.from = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 2:
+            message.to = $root.google.protobuf.Timestamp.decode(reader, reader.uint32())
+            break
+          case 3:
+            message.labels = reader.string()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a DroppedStream message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.DroppedStream
@@ -3467,13 +3262,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        DroppedStream.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    DroppedStream.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a DroppedStream message.
          * @function verify
          * @memberof logproto.DroppedStream
@@ -3481,26 +3275,23 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        DroppedStream.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.from != null && message.hasOwnProperty("from")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.from);
-                if (error)
-                    return "from." + error;
-            }
-            if (message.to != null && message.hasOwnProperty("to")) {
-                var error = $root.google.protobuf.Timestamp.verify(message.to);
-                if (error)
-                    return "to." + error;
-            }
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                if (!$util.isString(message.labels))
-                    return "labels: string expected";
-            return null;
-        };
+    DroppedStream.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.from != null && message.hasOwnProperty('from')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.from)
+        if (error) { return 'from.' + error }
+      }
+      if (message.to != null && message.hasOwnProperty('to')) {
+        var error = $root.google.protobuf.Timestamp.verify(message.to)
+        if (error) { return 'to.' + error }
+      }
+      if (message.labels != null && message.hasOwnProperty('labels')) {
+        if (!$util.isString(message.labels)) { return 'labels: string expected' }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a DroppedStream message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.DroppedStream
@@ -3508,26 +3299,22 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.DroppedStream} DroppedStream
          */
-        DroppedStream.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.DroppedStream)
-                return object;
-            var message = new $root.logproto.DroppedStream();
-            if (object.from != null) {
-                if (typeof object.from !== "object")
-                    throw TypeError(".logproto.DroppedStream.from: object expected");
-                message.from = $root.google.protobuf.Timestamp.fromObject(object.from);
-            }
-            if (object.to != null) {
-                if (typeof object.to !== "object")
-                    throw TypeError(".logproto.DroppedStream.to: object expected");
-                message.to = $root.google.protobuf.Timestamp.fromObject(object.to);
-            }
-            if (object.labels != null)
-                message.labels = String(object.labels);
-            return message;
-        };
+    DroppedStream.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.DroppedStream) { return object }
+      var message = new $root.logproto.DroppedStream()
+      if (object.from != null) {
+        if (typeof object.from !== 'object') { throw TypeError('.logproto.DroppedStream.from: object expected') }
+        message.from = $root.google.protobuf.Timestamp.fromObject(object.from)
+      }
+      if (object.to != null) {
+        if (typeof object.to !== 'object') { throw TypeError('.logproto.DroppedStream.to: object expected') }
+        message.to = $root.google.protobuf.Timestamp.fromObject(object.to)
+      }
+      if (object.labels != null) { message.labels = String(object.labels) }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a DroppedStream message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.DroppedStream
@@ -3536,41 +3323,36 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        DroppedStream.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.from = null;
-                object.to = null;
-                object.labels = "";
-            }
-            if (message.from != null && message.hasOwnProperty("from"))
-                object.from = $root.google.protobuf.Timestamp.toObject(message.from, options);
-            if (message.to != null && message.hasOwnProperty("to"))
-                object.to = $root.google.protobuf.Timestamp.toObject(message.to, options);
-            if (message.labels != null && message.hasOwnProperty("labels"))
-                object.labels = message.labels;
-            return object;
-        };
+    DroppedStream.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        object.from = null
+        object.to = null
+        object.labels = ''
+      }
+      if (message.from != null && message.hasOwnProperty('from')) { object.from = $root.google.protobuf.Timestamp.toObject(message.from, options) }
+      if (message.to != null && message.hasOwnProperty('to')) { object.to = $root.google.protobuf.Timestamp.toObject(message.to, options) }
+      if (message.labels != null && message.hasOwnProperty('labels')) { object.labels = message.labels }
+      return object
+    }
 
-        /**
+    /**
          * Converts this DroppedStream to JSON.
          * @function toJSON
          * @memberof logproto.DroppedStream
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        DroppedStream.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    DroppedStream.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return DroppedStream;
-    })();
+    return DroppedStream
+  })()
 
-    logproto.TimeSeriesChunk = (function() {
-
-        /**
+  logproto.TimeSeriesChunk = (function () {
+    /**
          * Properties of a TimeSeriesChunk.
          * @memberof logproto
          * @interface ITimeSeriesChunk
@@ -3580,7 +3362,7 @@ $root.logproto = (function() {
          * @property {Array.<logproto.IChunk>|null} [chunks] TimeSeriesChunk chunks
          */
 
-        /**
+    /**
          * Constructs a new TimeSeriesChunk.
          * @memberof logproto
          * @classdesc Represents a TimeSeriesChunk.
@@ -3588,48 +3370,49 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ITimeSeriesChunk=} [properties] Properties to set
          */
-        function TimeSeriesChunk(properties) {
-            this.labels = [];
-            this.chunks = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function TimeSeriesChunk (properties) {
+      this.labels = []
+      this.chunks = []
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * TimeSeriesChunk fromIngesterId.
          * @member {string} fromIngesterId
          * @memberof logproto.TimeSeriesChunk
          * @instance
          */
-        TimeSeriesChunk.prototype.fromIngesterId = "";
+    TimeSeriesChunk.prototype.fromIngesterId = ''
 
-        /**
+    /**
          * TimeSeriesChunk userId.
          * @member {string} userId
          * @memberof logproto.TimeSeriesChunk
          * @instance
          */
-        TimeSeriesChunk.prototype.userId = "";
+    TimeSeriesChunk.prototype.userId = ''
 
-        /**
+    /**
          * TimeSeriesChunk labels.
          * @member {Array.<logproto.ILabelPair>} labels
          * @memberof logproto.TimeSeriesChunk
          * @instance
          */
-        TimeSeriesChunk.prototype.labels = $util.emptyArray;
+    TimeSeriesChunk.prototype.labels = $util.emptyArray
 
-        /**
+    /**
          * TimeSeriesChunk chunks.
          * @member {Array.<logproto.IChunk>} chunks
          * @memberof logproto.TimeSeriesChunk
          * @instance
          */
-        TimeSeriesChunk.prototype.chunks = $util.emptyArray;
+    TimeSeriesChunk.prototype.chunks = $util.emptyArray
 
-        /**
+    /**
          * Creates a new TimeSeriesChunk instance using the specified properties.
          * @function create
          * @memberof logproto.TimeSeriesChunk
@@ -3637,11 +3420,11 @@ $root.logproto = (function() {
          * @param {logproto.ITimeSeriesChunk=} [properties] Properties to set
          * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk instance
          */
-        TimeSeriesChunk.create = function create(properties) {
-            return new TimeSeriesChunk(properties);
-        };
+    TimeSeriesChunk.create = function create (properties) {
+      return new TimeSeriesChunk(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified TimeSeriesChunk message. Does not implicitly {@link logproto.TimeSeriesChunk.verify|verify} messages.
          * @function encode
          * @memberof logproto.TimeSeriesChunk
@@ -3650,23 +3433,20 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TimeSeriesChunk.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.fromIngesterId != null && message.hasOwnProperty("fromIngesterId"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.fromIngesterId);
-            if (message.userId != null && message.hasOwnProperty("userId"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.userId);
-            if (message.labels != null && message.labels.length)
-                for (var i = 0; i < message.labels.length; ++i)
-                    $root.logproto.LabelPair.encode(message.labels[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-            if (message.chunks != null && message.chunks.length)
-                for (var i = 0; i < message.chunks.length; ++i)
-                    $root.logproto.Chunk.encode(message.chunks[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-            return writer;
-        };
+    TimeSeriesChunk.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.fromIngesterId != null && message.hasOwnProperty('fromIngesterId')) { writer.uint32(/* id 1, wireType 2 = */10).string(message.fromIngesterId) }
+      if (message.userId != null && message.hasOwnProperty('userId')) { writer.uint32(/* id 2, wireType 2 = */18).string(message.userId) }
+      if (message.labels != null && message.labels.length) {
+        for (var i = 0; i < message.labels.length; ++i) { $root.logproto.LabelPair.encode(message.labels[i], writer.uint32(/* id 3, wireType 2 = */26).fork()).ldelim() }
+      }
+      if (message.chunks != null && message.chunks.length) {
+        for (var i = 0; i < message.chunks.length; ++i) { $root.logproto.Chunk.encode(message.chunks[i], writer.uint32(/* id 4, wireType 2 = */34).fork()).ldelim() }
+      }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified TimeSeriesChunk message, length delimited. Does not implicitly {@link logproto.TimeSeriesChunk.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.TimeSeriesChunk
@@ -3675,11 +3455,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TimeSeriesChunk.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    TimeSeriesChunk.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a TimeSeriesChunk message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.TimeSeriesChunk
@@ -3690,38 +3470,35 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TimeSeriesChunk.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TimeSeriesChunk();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.fromIngesterId = reader.string();
-                    break;
-                case 2:
-                    message.userId = reader.string();
-                    break;
-                case 3:
-                    if (!(message.labels && message.labels.length))
-                        message.labels = [];
-                    message.labels.push($root.logproto.LabelPair.decode(reader, reader.uint32()));
-                    break;
-                case 4:
-                    if (!(message.chunks && message.chunks.length))
-                        message.chunks = [];
-                    message.chunks.push($root.logproto.Chunk.decode(reader, reader.uint32()));
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    TimeSeriesChunk.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.TimeSeriesChunk()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.fromIngesterId = reader.string()
+            break
+          case 2:
+            message.userId = reader.string()
+            break
+          case 3:
+            if (!(message.labels && message.labels.length)) { message.labels = [] }
+            message.labels.push($root.logproto.LabelPair.decode(reader, reader.uint32()))
+            break
+          case 4:
+            if (!(message.chunks && message.chunks.length)) { message.chunks = [] }
+            message.chunks.push($root.logproto.Chunk.decode(reader, reader.uint32()))
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a TimeSeriesChunk message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.TimeSeriesChunk
@@ -3731,13 +3508,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TimeSeriesChunk.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    TimeSeriesChunk.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a TimeSeriesChunk message.
          * @function verify
          * @memberof logproto.TimeSeriesChunk
@@ -3745,37 +3521,32 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        TimeSeriesChunk.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.fromIngesterId != null && message.hasOwnProperty("fromIngesterId"))
-                if (!$util.isString(message.fromIngesterId))
-                    return "fromIngesterId: string expected";
-            if (message.userId != null && message.hasOwnProperty("userId"))
-                if (!$util.isString(message.userId))
-                    return "userId: string expected";
-            if (message.labels != null && message.hasOwnProperty("labels")) {
-                if (!Array.isArray(message.labels))
-                    return "labels: array expected";
-                for (var i = 0; i < message.labels.length; ++i) {
-                    var error = $root.logproto.LabelPair.verify(message.labels[i]);
-                    if (error)
-                        return "labels." + error;
-                }
-            }
-            if (message.chunks != null && message.hasOwnProperty("chunks")) {
-                if (!Array.isArray(message.chunks))
-                    return "chunks: array expected";
-                for (var i = 0; i < message.chunks.length; ++i) {
-                    var error = $root.logproto.Chunk.verify(message.chunks[i]);
-                    if (error)
-                        return "chunks." + error;
-                }
-            }
-            return null;
-        };
+    TimeSeriesChunk.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.fromIngesterId != null && message.hasOwnProperty('fromIngesterId')) {
+        if (!$util.isString(message.fromIngesterId)) { return 'fromIngesterId: string expected' }
+      }
+      if (message.userId != null && message.hasOwnProperty('userId')) {
+        if (!$util.isString(message.userId)) { return 'userId: string expected' }
+      }
+      if (message.labels != null && message.hasOwnProperty('labels')) {
+        if (!Array.isArray(message.labels)) { return 'labels: array expected' }
+        for (var i = 0; i < message.labels.length; ++i) {
+          var error = $root.logproto.LabelPair.verify(message.labels[i])
+          if (error) { return 'labels.' + error }
+        }
+      }
+      if (message.chunks != null && message.hasOwnProperty('chunks')) {
+        if (!Array.isArray(message.chunks)) { return 'chunks: array expected' }
+        for (var i = 0; i < message.chunks.length; ++i) {
+          var error = $root.logproto.Chunk.verify(message.chunks[i])
+          if (error) { return 'chunks.' + error }
+        }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a TimeSeriesChunk message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.TimeSeriesChunk
@@ -3783,38 +3554,31 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
          */
-        TimeSeriesChunk.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.TimeSeriesChunk)
-                return object;
-            var message = new $root.logproto.TimeSeriesChunk();
-            if (object.fromIngesterId != null)
-                message.fromIngesterId = String(object.fromIngesterId);
-            if (object.userId != null)
-                message.userId = String(object.userId);
-            if (object.labels) {
-                if (!Array.isArray(object.labels))
-                    throw TypeError(".logproto.TimeSeriesChunk.labels: array expected");
-                message.labels = [];
-                for (var i = 0; i < object.labels.length; ++i) {
-                    if (typeof object.labels[i] !== "object")
-                        throw TypeError(".logproto.TimeSeriesChunk.labels: object expected");
-                    message.labels[i] = $root.logproto.LabelPair.fromObject(object.labels[i]);
-                }
-            }
-            if (object.chunks) {
-                if (!Array.isArray(object.chunks))
-                    throw TypeError(".logproto.TimeSeriesChunk.chunks: array expected");
-                message.chunks = [];
-                for (var i = 0; i < object.chunks.length; ++i) {
-                    if (typeof object.chunks[i] !== "object")
-                        throw TypeError(".logproto.TimeSeriesChunk.chunks: object expected");
-                    message.chunks[i] = $root.logproto.Chunk.fromObject(object.chunks[i]);
-                }
-            }
-            return message;
-        };
+    TimeSeriesChunk.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.TimeSeriesChunk) { return object }
+      var message = new $root.logproto.TimeSeriesChunk()
+      if (object.fromIngesterId != null) { message.fromIngesterId = String(object.fromIngesterId) }
+      if (object.userId != null) { message.userId = String(object.userId) }
+      if (object.labels) {
+        if (!Array.isArray(object.labels)) { throw TypeError('.logproto.TimeSeriesChunk.labels: array expected') }
+        message.labels = []
+        for (var i = 0; i < object.labels.length; ++i) {
+          if (typeof object.labels[i] !== 'object') { throw TypeError('.logproto.TimeSeriesChunk.labels: object expected') }
+          message.labels[i] = $root.logproto.LabelPair.fromObject(object.labels[i])
+        }
+      }
+      if (object.chunks) {
+        if (!Array.isArray(object.chunks)) { throw TypeError('.logproto.TimeSeriesChunk.chunks: array expected') }
+        message.chunks = []
+        for (var i = 0; i < object.chunks.length; ++i) {
+          if (typeof object.chunks[i] !== 'object') { throw TypeError('.logproto.TimeSeriesChunk.chunks: object expected') }
+          message.chunks[i] = $root.logproto.Chunk.fromObject(object.chunks[i])
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a TimeSeriesChunk message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.TimeSeriesChunk
@@ -3823,52 +3587,46 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        TimeSeriesChunk.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults) {
-                object.labels = [];
-                object.chunks = [];
-            }
-            if (options.defaults) {
-                object.fromIngesterId = "";
-                object.userId = "";
-            }
-            if (message.fromIngesterId != null && message.hasOwnProperty("fromIngesterId"))
-                object.fromIngesterId = message.fromIngesterId;
-            if (message.userId != null && message.hasOwnProperty("userId"))
-                object.userId = message.userId;
-            if (message.labels && message.labels.length) {
-                object.labels = [];
-                for (var j = 0; j < message.labels.length; ++j)
-                    object.labels[j] = $root.logproto.LabelPair.toObject(message.labels[j], options);
-            }
-            if (message.chunks && message.chunks.length) {
-                object.chunks = [];
-                for (var j = 0; j < message.chunks.length; ++j)
-                    object.chunks[j] = $root.logproto.Chunk.toObject(message.chunks[j], options);
-            }
-            return object;
-        };
+    TimeSeriesChunk.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.arrays || options.defaults) {
+        object.labels = []
+        object.chunks = []
+      }
+      if (options.defaults) {
+        object.fromIngesterId = ''
+        object.userId = ''
+      }
+      if (message.fromIngesterId != null && message.hasOwnProperty('fromIngesterId')) { object.fromIngesterId = message.fromIngesterId }
+      if (message.userId != null && message.hasOwnProperty('userId')) { object.userId = message.userId }
+      if (message.labels && message.labels.length) {
+        object.labels = []
+        for (var j = 0; j < message.labels.length; ++j) { object.labels[j] = $root.logproto.LabelPair.toObject(message.labels[j], options) }
+      }
+      if (message.chunks && message.chunks.length) {
+        object.chunks = []
+        for (var j = 0; j < message.chunks.length; ++j) { object.chunks[j] = $root.logproto.Chunk.toObject(message.chunks[j], options) }
+      }
+      return object
+    }
 
-        /**
+    /**
          * Converts this TimeSeriesChunk to JSON.
          * @function toJSON
          * @memberof logproto.TimeSeriesChunk
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        TimeSeriesChunk.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    TimeSeriesChunk.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return TimeSeriesChunk;
-    })();
+    return TimeSeriesChunk
+  })()
 
-    logproto.LabelPair = (function() {
-
-        /**
+  logproto.LabelPair = (function () {
+    /**
          * Properties of a LabelPair.
          * @memberof logproto
          * @interface ILabelPair
@@ -3876,7 +3634,7 @@ $root.logproto = (function() {
          * @property {string|null} [value] LabelPair value
          */
 
-        /**
+    /**
          * Constructs a new LabelPair.
          * @memberof logproto
          * @classdesc Represents a LabelPair.
@@ -3884,30 +3642,31 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ILabelPair=} [properties] Properties to set
          */
-        function LabelPair(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function LabelPair (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * LabelPair name.
          * @member {string} name
          * @memberof logproto.LabelPair
          * @instance
          */
-        LabelPair.prototype.name = "";
+    LabelPair.prototype.name = ''
 
-        /**
+    /**
          * LabelPair value.
          * @member {string} value
          * @memberof logproto.LabelPair
          * @instance
          */
-        LabelPair.prototype.value = "";
+    LabelPair.prototype.value = ''
 
-        /**
+    /**
          * Creates a new LabelPair instance using the specified properties.
          * @function create
          * @memberof logproto.LabelPair
@@ -3915,11 +3674,11 @@ $root.logproto = (function() {
          * @param {logproto.ILabelPair=} [properties] Properties to set
          * @returns {logproto.LabelPair} LabelPair instance
          */
-        LabelPair.create = function create(properties) {
-            return new LabelPair(properties);
-        };
+    LabelPair.create = function create (properties) {
+      return new LabelPair(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified LabelPair message. Does not implicitly {@link logproto.LabelPair.verify|verify} messages.
          * @function encode
          * @memberof logproto.LabelPair
@@ -3928,17 +3687,14 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        LabelPair.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.name != null && message.hasOwnProperty("name"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-            if (message.value != null && message.hasOwnProperty("value"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.value);
-            return writer;
-        };
+    LabelPair.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.name != null && message.hasOwnProperty('name')) { writer.uint32(/* id 1, wireType 2 = */10).string(message.name) }
+      if (message.value != null && message.hasOwnProperty('value')) { writer.uint32(/* id 2, wireType 2 = */18).string(message.value) }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified LabelPair message, length delimited. Does not implicitly {@link logproto.LabelPair.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.LabelPair
@@ -3947,11 +3703,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        LabelPair.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    LabelPair.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a LabelPair message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.LabelPair
@@ -3962,28 +3718,27 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        LabelPair.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.LabelPair();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.name = reader.string();
-                    break;
-                case 2:
-                    message.value = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    LabelPair.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.LabelPair()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.name = reader.string()
+            break
+          case 2:
+            message.value = reader.string()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a LabelPair message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.LabelPair
@@ -3993,13 +3748,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        LabelPair.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    LabelPair.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a LabelPair message.
          * @function verify
          * @memberof logproto.LabelPair
@@ -4007,19 +3761,18 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        LabelPair.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.name != null && message.hasOwnProperty("name"))
-                if (!$util.isString(message.name))
-                    return "name: string expected";
-            if (message.value != null && message.hasOwnProperty("value"))
-                if (!$util.isString(message.value))
-                    return "value: string expected";
-            return null;
-        };
+    LabelPair.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.name != null && message.hasOwnProperty('name')) {
+        if (!$util.isString(message.name)) { return 'name: string expected' }
+      }
+      if (message.value != null && message.hasOwnProperty('value')) {
+        if (!$util.isString(message.value)) { return 'value: string expected' }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a LabelPair message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.LabelPair
@@ -4027,18 +3780,15 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.LabelPair} LabelPair
          */
-        LabelPair.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.LabelPair)
-                return object;
-            var message = new $root.logproto.LabelPair();
-            if (object.name != null)
-                message.name = String(object.name);
-            if (object.value != null)
-                message.value = String(object.value);
-            return message;
-        };
+    LabelPair.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.LabelPair) { return object }
+      var message = new $root.logproto.LabelPair()
+      if (object.name != null) { message.name = String(object.name) }
+      if (object.value != null) { message.value = String(object.value) }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a LabelPair message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.LabelPair
@@ -4047,45 +3797,41 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        LabelPair.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.name = "";
-                object.value = "";
-            }
-            if (message.name != null && message.hasOwnProperty("name"))
-                object.name = message.name;
-            if (message.value != null && message.hasOwnProperty("value"))
-                object.value = message.value;
-            return object;
-        };
+    LabelPair.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        object.name = ''
+        object.value = ''
+      }
+      if (message.name != null && message.hasOwnProperty('name')) { object.name = message.name }
+      if (message.value != null && message.hasOwnProperty('value')) { object.value = message.value }
+      return object
+    }
 
-        /**
+    /**
          * Converts this LabelPair to JSON.
          * @function toJSON
          * @memberof logproto.LabelPair
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        LabelPair.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    LabelPair.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return LabelPair;
-    })();
+    return LabelPair
+  })()
 
-    logproto.Chunk = (function() {
-
-        /**
+  logproto.Chunk = (function () {
+    /**
          * Properties of a Chunk.
          * @memberof logproto
          * @interface IChunk
          * @property {Uint8Array|null} [data] Chunk data
          */
 
-        /**
+    /**
          * Constructs a new Chunk.
          * @memberof logproto
          * @classdesc Represents a Chunk.
@@ -4093,22 +3839,23 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.IChunk=} [properties] Properties to set
          */
-        function Chunk(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function Chunk (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * Chunk data.
          * @member {Uint8Array} data
          * @memberof logproto.Chunk
          * @instance
          */
-        Chunk.prototype.data = $util.newBuffer([]);
+    Chunk.prototype.data = $util.newBuffer([])
 
-        /**
+    /**
          * Creates a new Chunk instance using the specified properties.
          * @function create
          * @memberof logproto.Chunk
@@ -4116,11 +3863,11 @@ $root.logproto = (function() {
          * @param {logproto.IChunk=} [properties] Properties to set
          * @returns {logproto.Chunk} Chunk instance
          */
-        Chunk.create = function create(properties) {
-            return new Chunk(properties);
-        };
+    Chunk.create = function create (properties) {
+      return new Chunk(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified Chunk message. Does not implicitly {@link logproto.Chunk.verify|verify} messages.
          * @function encode
          * @memberof logproto.Chunk
@@ -4129,15 +3876,13 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Chunk.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.data != null && message.hasOwnProperty("data"))
-                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.data);
-            return writer;
-        };
+    Chunk.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.data != null && message.hasOwnProperty('data')) { writer.uint32(/* id 1, wireType 2 = */10).bytes(message.data) }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified Chunk message, length delimited. Does not implicitly {@link logproto.Chunk.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.Chunk
@@ -4146,11 +3891,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Chunk.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    Chunk.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a Chunk message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.Chunk
@@ -4161,25 +3906,24 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Chunk.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.Chunk();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.data = reader.bytes();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    Chunk.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.Chunk()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.data = reader.bytes()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a Chunk message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.Chunk
@@ -4189,13 +3933,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Chunk.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    Chunk.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a Chunk message.
          * @function verify
          * @memberof logproto.Chunk
@@ -4203,16 +3946,15 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        Chunk.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.data != null && message.hasOwnProperty("data"))
-                if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
-                    return "data: buffer expected";
-            return null;
-        };
+    Chunk.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.data != null && message.hasOwnProperty('data')) {
+        if (!(message.data && typeof message.data.length === 'number' || $util.isString(message.data))) { return 'data: buffer expected' }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a Chunk message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.Chunk
@@ -4220,19 +3962,16 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.Chunk} Chunk
          */
-        Chunk.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.Chunk)
-                return object;
-            var message = new $root.logproto.Chunk();
-            if (object.data != null)
-                if (typeof object.data === "string")
-                    $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
-                else if (object.data.length)
-                    message.data = object.data;
-            return message;
-        };
+    Chunk.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.Chunk) { return object }
+      var message = new $root.logproto.Chunk()
+      if (object.data != null) {
+        if (typeof object.data === 'string') { $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0) } else if (object.data.length) { message.data = object.data }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a Chunk message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.Chunk
@@ -4241,46 +3980,41 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Chunk.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults)
-                if (options.bytes === String)
-                    object.data = "";
-                else {
-                    object.data = [];
-                    if (options.bytes !== Array)
-                        object.data = $util.newBuffer(object.data);
-                }
-            if (message.data != null && message.hasOwnProperty("data"))
-                object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
-            return object;
-        };
+    Chunk.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) {
+        if (options.bytes === String) { object.data = '' } else {
+          object.data = []
+          if (options.bytes !== Array) { object.data = $util.newBuffer(object.data) }
+        }
+      }
+      if (message.data != null && message.hasOwnProperty('data')) { object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data }
+      return object
+    }
 
-        /**
+    /**
          * Converts this Chunk to JSON.
          * @function toJSON
          * @memberof logproto.Chunk
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        Chunk.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    Chunk.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return Chunk;
-    })();
+    return Chunk
+  })()
 
-    logproto.TransferChunksResponse = (function() {
-
-        /**
+  logproto.TransferChunksResponse = (function () {
+    /**
          * Properties of a TransferChunksResponse.
          * @memberof logproto
          * @interface ITransferChunksResponse
          */
 
-        /**
+    /**
          * Constructs a new TransferChunksResponse.
          * @memberof logproto
          * @classdesc Represents a TransferChunksResponse.
@@ -4288,14 +4022,15 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ITransferChunksResponse=} [properties] Properties to set
          */
-        function TransferChunksResponse(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function TransferChunksResponse (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * Creates a new TransferChunksResponse instance using the specified properties.
          * @function create
          * @memberof logproto.TransferChunksResponse
@@ -4303,11 +4038,11 @@ $root.logproto = (function() {
          * @param {logproto.ITransferChunksResponse=} [properties] Properties to set
          * @returns {logproto.TransferChunksResponse} TransferChunksResponse instance
          */
-        TransferChunksResponse.create = function create(properties) {
-            return new TransferChunksResponse(properties);
-        };
+    TransferChunksResponse.create = function create (properties) {
+      return new TransferChunksResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified TransferChunksResponse message. Does not implicitly {@link logproto.TransferChunksResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.TransferChunksResponse
@@ -4316,13 +4051,12 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TransferChunksResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            return writer;
-        };
+    TransferChunksResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified TransferChunksResponse message, length delimited. Does not implicitly {@link logproto.TransferChunksResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.TransferChunksResponse
@@ -4331,11 +4065,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TransferChunksResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    TransferChunksResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a TransferChunksResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.TransferChunksResponse
@@ -4346,22 +4080,21 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TransferChunksResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TransferChunksResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    TransferChunksResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.TransferChunksResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a TransferChunksResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.TransferChunksResponse
@@ -4371,13 +4104,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TransferChunksResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    TransferChunksResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a TransferChunksResponse message.
          * @function verify
          * @memberof logproto.TransferChunksResponse
@@ -4385,13 +4117,12 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        TransferChunksResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            return null;
-        };
+    TransferChunksResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      return null
+    }
 
-        /**
+    /**
          * Creates a TransferChunksResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.TransferChunksResponse
@@ -4399,13 +4130,12 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.TransferChunksResponse} TransferChunksResponse
          */
-        TransferChunksResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.TransferChunksResponse)
-                return object;
-            return new $root.logproto.TransferChunksResponse();
-        };
+    TransferChunksResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.TransferChunksResponse) { return object }
+      return new $root.logproto.TransferChunksResponse()
+    }
 
-        /**
+    /**
          * Creates a plain object from a TransferChunksResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.TransferChunksResponse
@@ -4414,33 +4144,32 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        TransferChunksResponse.toObject = function toObject() {
-            return {};
-        };
+    TransferChunksResponse.toObject = function toObject () {
+      return {}
+    }
 
-        /**
+    /**
          * Converts this TransferChunksResponse to JSON.
          * @function toJSON
          * @memberof logproto.TransferChunksResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        TransferChunksResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    TransferChunksResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return TransferChunksResponse;
-    })();
+    return TransferChunksResponse
+  })()
 
-    logproto.TailersCountRequest = (function() {
-
-        /**
+  logproto.TailersCountRequest = (function () {
+    /**
          * Properties of a TailersCountRequest.
          * @memberof logproto
          * @interface ITailersCountRequest
          */
 
-        /**
+    /**
          * Constructs a new TailersCountRequest.
          * @memberof logproto
          * @classdesc Represents a TailersCountRequest.
@@ -4448,14 +4177,15 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ITailersCountRequest=} [properties] Properties to set
          */
-        function TailersCountRequest(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function TailersCountRequest (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * Creates a new TailersCountRequest instance using the specified properties.
          * @function create
          * @memberof logproto.TailersCountRequest
@@ -4463,11 +4193,11 @@ $root.logproto = (function() {
          * @param {logproto.ITailersCountRequest=} [properties] Properties to set
          * @returns {logproto.TailersCountRequest} TailersCountRequest instance
          */
-        TailersCountRequest.create = function create(properties) {
-            return new TailersCountRequest(properties);
-        };
+    TailersCountRequest.create = function create (properties) {
+      return new TailersCountRequest(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified TailersCountRequest message. Does not implicitly {@link logproto.TailersCountRequest.verify|verify} messages.
          * @function encode
          * @memberof logproto.TailersCountRequest
@@ -4476,13 +4206,12 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailersCountRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            return writer;
-        };
+    TailersCountRequest.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified TailersCountRequest message, length delimited. Does not implicitly {@link logproto.TailersCountRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.TailersCountRequest
@@ -4491,11 +4220,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailersCountRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    TailersCountRequest.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a TailersCountRequest message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.TailersCountRequest
@@ -4506,22 +4235,21 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailersCountRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailersCountRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    TailersCountRequest.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.TailersCountRequest()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a TailersCountRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.TailersCountRequest
@@ -4531,13 +4259,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailersCountRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    TailersCountRequest.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a TailersCountRequest message.
          * @function verify
          * @memberof logproto.TailersCountRequest
@@ -4545,13 +4272,12 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        TailersCountRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            return null;
-        };
+    TailersCountRequest.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      return null
+    }
 
-        /**
+    /**
          * Creates a TailersCountRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.TailersCountRequest
@@ -4559,13 +4285,12 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.TailersCountRequest} TailersCountRequest
          */
-        TailersCountRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.TailersCountRequest)
-                return object;
-            return new $root.logproto.TailersCountRequest();
-        };
+    TailersCountRequest.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.TailersCountRequest) { return object }
+      return new $root.logproto.TailersCountRequest()
+    }
 
-        /**
+    /**
          * Creates a plain object from a TailersCountRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.TailersCountRequest
@@ -4574,34 +4299,33 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        TailersCountRequest.toObject = function toObject() {
-            return {};
-        };
+    TailersCountRequest.toObject = function toObject () {
+      return {}
+    }
 
-        /**
+    /**
          * Converts this TailersCountRequest to JSON.
          * @function toJSON
          * @memberof logproto.TailersCountRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        TailersCountRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    TailersCountRequest.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return TailersCountRequest;
-    })();
+    return TailersCountRequest
+  })()
 
-    logproto.TailersCountResponse = (function() {
-
-        /**
+  logproto.TailersCountResponse = (function () {
+    /**
          * Properties of a TailersCountResponse.
          * @memberof logproto
          * @interface ITailersCountResponse
          * @property {number|null} [count] TailersCountResponse count
          */
 
-        /**
+    /**
          * Constructs a new TailersCountResponse.
          * @memberof logproto
          * @classdesc Represents a TailersCountResponse.
@@ -4609,22 +4333,23 @@ $root.logproto = (function() {
          * @constructor
          * @param {logproto.ITailersCountResponse=} [properties] Properties to set
          */
-        function TailersCountResponse(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
+    function TailersCountResponse (properties) {
+      if (properties) {
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+          if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
         }
+      }
+    }
 
-        /**
+    /**
          * TailersCountResponse count.
          * @member {number} count
          * @memberof logproto.TailersCountResponse
          * @instance
          */
-        TailersCountResponse.prototype.count = 0;
+    TailersCountResponse.prototype.count = 0
 
-        /**
+    /**
          * Creates a new TailersCountResponse instance using the specified properties.
          * @function create
          * @memberof logproto.TailersCountResponse
@@ -4632,11 +4357,11 @@ $root.logproto = (function() {
          * @param {logproto.ITailersCountResponse=} [properties] Properties to set
          * @returns {logproto.TailersCountResponse} TailersCountResponse instance
          */
-        TailersCountResponse.create = function create(properties) {
-            return new TailersCountResponse(properties);
-        };
+    TailersCountResponse.create = function create (properties) {
+      return new TailersCountResponse(properties)
+    }
 
-        /**
+    /**
          * Encodes the specified TailersCountResponse message. Does not implicitly {@link logproto.TailersCountResponse.verify|verify} messages.
          * @function encode
          * @memberof logproto.TailersCountResponse
@@ -4645,15 +4370,13 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailersCountResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.count != null && message.hasOwnProperty("count"))
-                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.count);
-            return writer;
-        };
+    TailersCountResponse.encode = function encode (message, writer) {
+      if (!writer) { writer = $Writer.create() }
+      if (message.count != null && message.hasOwnProperty('count')) { writer.uint32(/* id 1, wireType 0 = */8).uint32(message.count) }
+      return writer
+    }
 
-        /**
+    /**
          * Encodes the specified TailersCountResponse message, length delimited. Does not implicitly {@link logproto.TailersCountResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof logproto.TailersCountResponse
@@ -4662,11 +4385,11 @@ $root.logproto = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        TailersCountResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+    TailersCountResponse.encodeDelimited = function encodeDelimited (message, writer) {
+      return this.encode(message, writer).ldelim()
+    }
 
-        /**
+    /**
          * Decodes a TailersCountResponse message from the specified reader or buffer.
          * @function decode
          * @memberof logproto.TailersCountResponse
@@ -4677,25 +4400,24 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailersCountResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailersCountResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.count = reader.uint32();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
+    TailersCountResponse.decode = function decode (reader, length) {
+      if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+      var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.logproto.TailersCountResponse()
+      while (reader.pos < end) {
+        var tag = reader.uint32()
+        switch (tag >>> 3) {
+          case 1:
+            message.count = reader.uint32()
+            break
+          default:
+            reader.skipType(tag & 7)
+            break
+        }
+      }
+      return message
+    }
 
-        /**
+    /**
          * Decodes a TailersCountResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof logproto.TailersCountResponse
@@ -4705,13 +4427,12 @@ $root.logproto = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        TailersCountResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+    TailersCountResponse.decodeDelimited = function decodeDelimited (reader) {
+      if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+      return this.decode(reader, reader.uint32())
+    }
 
-        /**
+    /**
          * Verifies a TailersCountResponse message.
          * @function verify
          * @memberof logproto.TailersCountResponse
@@ -4719,16 +4440,15 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        TailersCountResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.count != null && message.hasOwnProperty("count"))
-                if (!$util.isInteger(message.count))
-                    return "count: integer expected";
-            return null;
-        };
+    TailersCountResponse.verify = function verify (message) {
+      if (typeof message !== 'object' || message === null) { return 'object expected' }
+      if (message.count != null && message.hasOwnProperty('count')) {
+        if (!$util.isInteger(message.count)) { return 'count: integer expected' }
+      }
+      return null
+    }
 
-        /**
+    /**
          * Creates a TailersCountResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof logproto.TailersCountResponse
@@ -4736,16 +4456,14 @@ $root.logproto = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {logproto.TailersCountResponse} TailersCountResponse
          */
-        TailersCountResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.logproto.TailersCountResponse)
-                return object;
-            var message = new $root.logproto.TailersCountResponse();
-            if (object.count != null)
-                message.count = object.count >>> 0;
-            return message;
-        };
+    TailersCountResponse.fromObject = function fromObject (object) {
+      if (object instanceof $root.logproto.TailersCountResponse) { return object }
+      var message = new $root.logproto.TailersCountResponse()
+      if (object.count != null) { message.count = object.count >>> 0 }
+      return message
+    }
 
-        /**
+    /**
          * Creates a plain object from a TailersCountResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof logproto.TailersCountResponse
@@ -4754,55 +4472,49 @@ $root.logproto = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        TailersCountResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults)
-                object.count = 0;
-            if (message.count != null && message.hasOwnProperty("count"))
-                object.count = message.count;
-            return object;
-        };
+    TailersCountResponse.toObject = function toObject (message, options) {
+      if (!options) { options = {} }
+      var object = {}
+      if (options.defaults) { object.count = 0 }
+      if (message.count != null && message.hasOwnProperty('count')) { object.count = message.count }
+      return object
+    }
 
-        /**
+    /**
          * Converts this TailersCountResponse to JSON.
          * @function toJSON
          * @memberof logproto.TailersCountResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        TailersCountResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+    TailersCountResponse.prototype.toJSON = function toJSON () {
+      return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+    }
 
-        return TailersCountResponse;
-    })();
+    return TailersCountResponse
+  })()
 
-    return logproto;
-})();
+  return logproto
+})()
 
-$root.google = (function() {
-
-    /**
+$root.google = (function () {
+  /**
      * Namespace google.
      * @exports google
      * @namespace
      */
-    var google = {};
+  var google = {}
 
-    google.protobuf = (function() {
-
-        /**
+  google.protobuf = (function () {
+    /**
          * Namespace protobuf.
          * @memberof google
          * @namespace
          */
-        var protobuf = {};
+    var protobuf = {}
 
-        protobuf.Timestamp = (function() {
-
-            /**
+    protobuf.Timestamp = (function () {
+      /**
              * Properties of a Timestamp.
              * @memberof google.protobuf
              * @interface ITimestamp
@@ -4810,7 +4522,7 @@ $root.google = (function() {
              * @property {number|null} [nanos] Timestamp nanos
              */
 
-            /**
+      /**
              * Constructs a new Timestamp.
              * @memberof google.protobuf
              * @classdesc Represents a Timestamp.
@@ -4818,30 +4530,31 @@ $root.google = (function() {
              * @constructor
              * @param {google.protobuf.ITimestamp=} [properties] Properties to set
              */
-            function Timestamp(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
+      function Timestamp (properties) {
+        if (properties) {
+          for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+            if (properties[keys[i]] != null) { this[keys[i]] = properties[keys[i]] }
+          }
+        }
+      }
 
-            /**
+      /**
              * Timestamp seconds.
              * @member {number|Long} seconds
              * @memberof google.protobuf.Timestamp
              * @instance
              */
-            Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+      Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0, 0, false) : 0
 
-            /**
+      /**
              * Timestamp nanos.
              * @member {number} nanos
              * @memberof google.protobuf.Timestamp
              * @instance
              */
-            Timestamp.prototype.nanos = 0;
+      Timestamp.prototype.nanos = 0
 
-            /**
+      /**
              * Creates a new Timestamp instance using the specified properties.
              * @function create
              * @memberof google.protobuf.Timestamp
@@ -4849,11 +4562,11 @@ $root.google = (function() {
              * @param {google.protobuf.ITimestamp=} [properties] Properties to set
              * @returns {google.protobuf.Timestamp} Timestamp instance
              */
-            Timestamp.create = function create(properties) {
-                return new Timestamp(properties);
-            };
+      Timestamp.create = function create (properties) {
+        return new Timestamp(properties)
+      }
 
-            /**
+      /**
              * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
              * @function encode
              * @memberof google.protobuf.Timestamp
@@ -4862,17 +4575,14 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Timestamp.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.seconds != null && message.hasOwnProperty("seconds"))
-                    writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
-                if (message.nanos != null && message.hasOwnProperty("nanos"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
-                return writer;
-            };
+      Timestamp.encode = function encode (message, writer) {
+        if (!writer) { writer = $Writer.create() }
+        if (message.seconds != null && message.hasOwnProperty('seconds')) { writer.uint32(/* id 1, wireType 0 = */8).int64(message.seconds) }
+        if (message.nanos != null && message.hasOwnProperty('nanos')) { writer.uint32(/* id 2, wireType 0 = */16).int32(message.nanos) }
+        return writer
+      }
 
-            /**
+      /**
              * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
              * @function encodeDelimited
              * @memberof google.protobuf.Timestamp
@@ -4881,11 +4591,11 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Timestamp.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
+      Timestamp.encodeDelimited = function encodeDelimited (message, writer) {
+        return this.encode(message, writer).ldelim()
+      }
 
-            /**
+      /**
              * Decodes a Timestamp message from the specified reader or buffer.
              * @function decode
              * @memberof google.protobuf.Timestamp
@@ -4896,28 +4606,27 @@ $root.google = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Timestamp.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Timestamp();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.seconds = reader.int64();
-                        break;
-                    case 2:
-                        message.nanos = reader.int32();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
+      Timestamp.decode = function decode (reader, length) {
+        if (!(reader instanceof $Reader)) { reader = $Reader.create(reader) }
+        var end = length === undefined ? reader.len : reader.pos + length; var message = new $root.google.protobuf.Timestamp()
+        while (reader.pos < end) {
+          var tag = reader.uint32()
+          switch (tag >>> 3) {
+            case 1:
+              message.seconds = reader.int64()
+              break
+            case 2:
+              message.nanos = reader.int32()
+              break
+            default:
+              reader.skipType(tag & 7)
+              break
+          }
+        }
+        return message
+      }
 
-            /**
+      /**
              * Decodes a Timestamp message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
              * @memberof google.protobuf.Timestamp
@@ -4927,13 +4636,12 @@ $root.google = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Timestamp.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
+      Timestamp.decodeDelimited = function decodeDelimited (reader) {
+        if (!(reader instanceof $Reader)) { reader = new $Reader(reader) }
+        return this.decode(reader, reader.uint32())
+      }
 
-            /**
+      /**
              * Verifies a Timestamp message.
              * @function verify
              * @memberof google.protobuf.Timestamp
@@ -4941,19 +4649,18 @@ $root.google = (function() {
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-            Timestamp.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.seconds != null && message.hasOwnProperty("seconds"))
-                    if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
-                        return "seconds: integer|Long expected";
-                if (message.nanos != null && message.hasOwnProperty("nanos"))
-                    if (!$util.isInteger(message.nanos))
-                        return "nanos: integer expected";
-                return null;
-            };
+      Timestamp.verify = function verify (message) {
+        if (typeof message !== 'object' || message === null) { return 'object expected' }
+        if (message.seconds != null && message.hasOwnProperty('seconds')) {
+          if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high))) { return 'seconds: integer|Long expected' }
+        }
+        if (message.nanos != null && message.hasOwnProperty('nanos')) {
+          if (!$util.isInteger(message.nanos)) { return 'nanos: integer expected' }
+        }
+        return null
+      }
 
-            /**
+      /**
              * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
              * @memberof google.protobuf.Timestamp
@@ -4961,25 +4668,17 @@ $root.google = (function() {
              * @param {Object.<string,*>} object Plain object
              * @returns {google.protobuf.Timestamp} Timestamp
              */
-            Timestamp.fromObject = function fromObject(object) {
-                if (object instanceof $root.google.protobuf.Timestamp)
-                    return object;
-                var message = new $root.google.protobuf.Timestamp();
-                if (object.seconds != null)
-                    if ($util.Long)
-                        (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
-                    else if (typeof object.seconds === "string")
-                        message.seconds = parseInt(object.seconds, 10);
-                    else if (typeof object.seconds === "number")
-                        message.seconds = object.seconds;
-                    else if (typeof object.seconds === "object")
-                        message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
-                if (object.nanos != null)
-                    message.nanos = object.nanos | 0;
-                return message;
-            };
+      Timestamp.fromObject = function fromObject (object) {
+        if (object instanceof $root.google.protobuf.Timestamp) { return object }
+        var message = new $root.google.protobuf.Timestamp()
+        if (object.seconds != null) {
+          if ($util.Long) { (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false } else if (typeof object.seconds === 'string') { message.seconds = parseInt(object.seconds, 10) } else if (typeof object.seconds === 'number') { message.seconds = object.seconds } else if (typeof object.seconds === 'object') { message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber() }
+        }
+        if (object.nanos != null) { message.nanos = object.nanos | 0 }
+        return message
+      }
 
-            /**
+      /**
              * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
              * @function toObject
              * @memberof google.protobuf.Timestamp
@@ -4988,46 +4687,41 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Timestamp.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    if ($util.Long) {
-                        var long = new $util.Long(0, 0, false);
-                        object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-                    } else
-                        object.seconds = options.longs === String ? "0" : 0;
-                    object.nanos = 0;
-                }
-                if (message.seconds != null && message.hasOwnProperty("seconds"))
-                    if (typeof message.seconds === "number")
-                        object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
-                    else
-                        object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
-                if (message.nanos != null && message.hasOwnProperty("nanos"))
-                    object.nanos = message.nanos;
-                return object;
-            };
+      Timestamp.toObject = function toObject (message, options) {
+        if (!options) { options = {} }
+        var object = {}
+        if (options.defaults) {
+          if ($util.Long) {
+            var long = new $util.Long(0, 0, false)
+            object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long
+          } else { object.seconds = options.longs === String ? '0' : 0 }
+          object.nanos = 0
+        }
+        if (message.seconds != null && message.hasOwnProperty('seconds')) {
+          if (typeof message.seconds === 'number') { object.seconds = options.longs === String ? String(message.seconds) : message.seconds } else { object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds }
+        }
+        if (message.nanos != null && message.hasOwnProperty('nanos')) { object.nanos = message.nanos }
+        return object
+      }
 
-            /**
+      /**
              * Converts this Timestamp to JSON.
              * @function toJSON
              * @memberof google.protobuf.Timestamp
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-            Timestamp.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
+      Timestamp.prototype.toJSON = function toJSON () {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions)
+      }
 
-            return Timestamp;
-        })();
+      return Timestamp
+    })()
 
-        return protobuf;
-    })();
+    return protobuf
+  })()
 
-    return google;
-})();
+  return google
+})()
 
-module.exports = $root;
+module.exports = $root

--- a/src/proto/index.js
+++ b/src/proto/index.js
@@ -1,4589 +1,5033 @@
-/* eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars */
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 "use strict";
 
 var $protobuf = require("protobufjs/minimal");
 
 // Common aliases
-var $Reader = $protobuf.Reader;
-var $Writer = $protobuf.Writer;
-var $util = $protobuf.util;
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
 var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
 
 $root.logproto = (function() {
-  /**
-   * Namespace logproto.
-   * @exports logproto
-   * @namespace
-   */
-  var logproto = {};
-
-  logproto.Pusher = (function() {
-    /**
-     * Constructs a new Pusher service.
-     * @memberof logproto
-     * @classdesc Represents a Pusher
-     * @extends $protobuf.rpc.Service
-     * @constructor
-     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
-     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
-     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
-     */
-    function Pusher(rpcImpl, requestDelimited, responseDelimited) {
-      $protobuf.rpc.Service.call(
-        this,
-        rpcImpl,
-        requestDelimited,
-        responseDelimited
-      );
-    }
-
-    (Pusher.prototype = Object.create(
-      $protobuf.rpc.Service.prototype
-    )).constructor = Pusher;
 
     /**
-     * Creates new Pusher service using the specified rpc implementation.
-     * @function create
-     * @memberof logproto.Pusher
-     * @static
-     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
-     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
-     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
-     * @returns {Pusher} RPC service. Useful where requests and/or responses are streamed.
+     * Namespace logproto.
+     * @exports logproto
+     * @namespace
      */
-    Pusher.create = function create(
-      rpcImpl,
-      requestDelimited,
-      responseDelimited
-    ) {
-      return new this(rpcImpl, requestDelimited, responseDelimited);
-    };
+    var logproto = {};
 
-    /**
-     * Callback as used by {@link logproto.Pusher#push}.
-     * @memberof logproto.Pusher
-     * @typedef PushCallback
-     * @type {function}
-     * @param {Error|null} error Error, if any
-     * @param {logproto.PushResponse} [response] PushResponse
-     */
+    logproto.Pusher = (function() {
 
-    /**
-     * Calls Push.
-     * @function push
-     * @memberof logproto.Pusher
-     * @instance
-     * @param {logproto.IPushRequest} request PushRequest message or plain object
-     * @param {logproto.Pusher.PushCallback} callback Node-style callback called with the error, if any, and PushResponse
-     * @returns {undefined}
-     * @variation 1
-     */
-    Object.defineProperty(
-      (Pusher.prototype.push = function push(request, callback) {
-        return this.rpcCall(
-          push,
-          $root.logproto.PushRequest,
-          $root.logproto.PushResponse,
-          request,
-          callback
-        );
-      }),
-      "name",
-      { value: "Push" }
-    );
-
-    /**
-     * Calls Push.
-     * @function push
-     * @memberof logproto.Pusher
-     * @instance
-     * @param {logproto.IPushRequest} request PushRequest message or plain object
-     * @returns {Promise<logproto.PushResponse>} Promise
-     * @variation 2
-     */
-
-    return Pusher;
-  })();
-
-  logproto.Querier = (function() {
-    /**
-     * Constructs a new Querier service.
-     * @memberof logproto
-     * @classdesc Represents a Querier
-     * @extends $protobuf.rpc.Service
-     * @constructor
-     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
-     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
-     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
-     */
-    function Querier(rpcImpl, requestDelimited, responseDelimited) {
-      $protobuf.rpc.Service.call(
-        this,
-        rpcImpl,
-        requestDelimited,
-        responseDelimited
-      );
-    }
-
-    (Querier.prototype = Object.create(
-      $protobuf.rpc.Service.prototype
-    )).constructor = Querier;
-
-    /**
-     * Creates new Querier service using the specified rpc implementation.
-     * @function create
-     * @memberof logproto.Querier
-     * @static
-     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
-     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
-     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
-     * @returns {Querier} RPC service. Useful where requests and/or responses are streamed.
-     */
-    Querier.create = function create(
-      rpcImpl,
-      requestDelimited,
-      responseDelimited
-    ) {
-      return new this(rpcImpl, requestDelimited, responseDelimited);
-    };
-
-    /**
-     * Callback as used by {@link logproto.Querier#query}.
-     * @memberof logproto.Querier
-     * @typedef QueryCallback
-     * @type {function}
-     * @param {Error|null} error Error, if any
-     * @param {logproto.QueryResponse} [response] QueryResponse
-     */
-
-    /**
-     * Calls Query.
-     * @function query
-     * @memberof logproto.Querier
-     * @instance
-     * @param {logproto.IQueryRequest} request QueryRequest message or plain object
-     * @param {logproto.Querier.QueryCallback} callback Node-style callback called with the error, if any, and QueryResponse
-     * @returns {undefined}
-     * @variation 1
-     */
-    Object.defineProperty(
-      (Querier.prototype.query = function query(request, callback) {
-        return this.rpcCall(
-          query,
-          $root.logproto.QueryRequest,
-          $root.logproto.QueryResponse,
-          request,
-          callback
-        );
-      }),
-      "name",
-      { value: "Query" }
-    );
-
-    /**
-     * Calls Query.
-     * @function query
-     * @memberof logproto.Querier
-     * @instance
-     * @param {logproto.IQueryRequest} request QueryRequest message or plain object
-     * @returns {Promise<logproto.QueryResponse>} Promise
-     * @variation 2
-     */
-
-    /**
-     * Callback as used by {@link logproto.Querier#label}.
-     * @memberof logproto.Querier
-     * @typedef LabelCallback
-     * @type {function}
-     * @param {Error|null} error Error, if any
-     * @param {logproto.LabelResponse} [response] LabelResponse
-     */
-
-    /**
-     * Calls Label.
-     * @function label
-     * @memberof logproto.Querier
-     * @instance
-     * @param {logproto.ILabelRequest} request LabelRequest message or plain object
-     * @param {logproto.Querier.LabelCallback} callback Node-style callback called with the error, if any, and LabelResponse
-     * @returns {undefined}
-     * @variation 1
-     */
-    Object.defineProperty(
-      (Querier.prototype.label = function label(request, callback) {
-        return this.rpcCall(
-          label,
-          $root.logproto.LabelRequest,
-          $root.logproto.LabelResponse,
-          request,
-          callback
-        );
-      }),
-      "name",
-      { value: "Label" }
-    );
-
-    /**
-     * Calls Label.
-     * @function label
-     * @memberof logproto.Querier
-     * @instance
-     * @param {logproto.ILabelRequest} request LabelRequest message or plain object
-     * @returns {Promise<logproto.LabelResponse>} Promise
-     * @variation 2
-     */
-
-    /**
-     * Callback as used by {@link logproto.Querier#tail}.
-     * @memberof logproto.Querier
-     * @typedef TailCallback
-     * @type {function}
-     * @param {Error|null} error Error, if any
-     * @param {logproto.TailResponse} [response] TailResponse
-     */
-
-    /**
-     * Calls Tail.
-     * @function tail
-     * @memberof logproto.Querier
-     * @instance
-     * @param {logproto.ITailRequest} request TailRequest message or plain object
-     * @param {logproto.Querier.TailCallback} callback Node-style callback called with the error, if any, and TailResponse
-     * @returns {undefined}
-     * @variation 1
-     */
-    Object.defineProperty(
-      (Querier.prototype.tail = function tail(request, callback) {
-        return this.rpcCall(
-          tail,
-          $root.logproto.TailRequest,
-          $root.logproto.TailResponse,
-          request,
-          callback
-        );
-      }),
-      "name",
-      { value: "Tail" }
-    );
-
-    /**
-     * Calls Tail.
-     * @function tail
-     * @memberof logproto.Querier
-     * @instance
-     * @param {logproto.ITailRequest} request TailRequest message or plain object
-     * @returns {Promise<logproto.TailResponse>} Promise
-     * @variation 2
-     */
-
-    return Querier;
-  })();
-
-  logproto.Ingester = (function() {
-    /**
-     * Constructs a new Ingester service.
-     * @memberof logproto
-     * @classdesc Represents an Ingester
-     * @extends $protobuf.rpc.Service
-     * @constructor
-     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
-     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
-     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
-     */
-    function Ingester(rpcImpl, requestDelimited, responseDelimited) {
-      $protobuf.rpc.Service.call(
-        this,
-        rpcImpl,
-        requestDelimited,
-        responseDelimited
-      );
-    }
-
-    (Ingester.prototype = Object.create(
-      $protobuf.rpc.Service.prototype
-    )).constructor = Ingester;
-
-    /**
-     * Creates new Ingester service using the specified rpc implementation.
-     * @function create
-     * @memberof logproto.Ingester
-     * @static
-     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
-     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
-     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
-     * @returns {Ingester} RPC service. Useful where requests and/or responses are streamed.
-     */
-    Ingester.create = function create(
-      rpcImpl,
-      requestDelimited,
-      responseDelimited
-    ) {
-      return new this(rpcImpl, requestDelimited, responseDelimited);
-    };
-
-    /**
-     * Callback as used by {@link logproto.Ingester#transferChunks}.
-     * @memberof logproto.Ingester
-     * @typedef TransferChunksCallback
-     * @type {function}
-     * @param {Error|null} error Error, if any
-     * @param {logproto.TransferChunksResponse} [response] TransferChunksResponse
-     */
-
-    /**
-     * Calls TransferChunks.
-     * @function transferChunks
-     * @memberof logproto.Ingester
-     * @instance
-     * @param {logproto.ITimeSeriesChunk} request TimeSeriesChunk message or plain object
-     * @param {logproto.Ingester.TransferChunksCallback} callback Node-style callback called with the error, if any, and TransferChunksResponse
-     * @returns {undefined}
-     * @variation 1
-     */
-    Object.defineProperty(
-      (Ingester.prototype.transferChunks = function transferChunks(
-        request,
-        callback
-      ) {
-        return this.rpcCall(
-          transferChunks,
-          $root.logproto.TimeSeriesChunk,
-          $root.logproto.TransferChunksResponse,
-          request,
-          callback
-        );
-      }),
-      "name",
-      { value: "TransferChunks" }
-    );
-
-    /**
-     * Calls TransferChunks.
-     * @function transferChunks
-     * @memberof logproto.Ingester
-     * @instance
-     * @param {logproto.ITimeSeriesChunk} request TimeSeriesChunk message or plain object
-     * @returns {Promise<logproto.TransferChunksResponse>} Promise
-     * @variation 2
-     */
-
-    return Ingester;
-  })();
-
-  logproto.PushRequest = (function() {
-    /**
-     * Properties of a PushRequest.
-     * @memberof logproto
-     * @interface IPushRequest
-     * @property {Array.<logproto.IStream>|null} [streams] PushRequest streams
-     */
-
-    /**
-     * Constructs a new PushRequest.
-     * @memberof logproto
-     * @classdesc Represents a PushRequest.
-     * @implements IPushRequest
-     * @constructor
-     * @param {logproto.IPushRequest=} [properties] Properties to set
-     */
-    function PushRequest(properties) {
-      this.streams = [];
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
+        /**
+         * Constructs a new Pusher service.
+         * @memberof logproto
+         * @classdesc Represents a Pusher
+         * @extends $protobuf.rpc.Service
+         * @constructor
+         * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+         * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+         * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+         */
+        function Pusher(rpcImpl, requestDelimited, responseDelimited) {
+            $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
         }
-      }
-    }
 
-    /**
-     * PushRequest streams.
-     * @member {Array.<logproto.IStream>} streams
-     * @memberof logproto.PushRequest
-     * @instance
-     */
-    PushRequest.prototype.streams = $util.emptyArray;
+        (Pusher.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Pusher;
 
-    /**
-     * Creates a new PushRequest instance using the specified properties.
-     * @function create
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {logproto.IPushRequest=} [properties] Properties to set
-     * @returns {logproto.PushRequest} PushRequest instance
-     */
-    PushRequest.create = function create(properties) {
-      return new PushRequest(properties);
-    };
+        /**
+         * Creates new Pusher service using the specified rpc implementation.
+         * @function create
+         * @memberof logproto.Pusher
+         * @static
+         * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+         * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+         * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+         * @returns {Pusher} RPC service. Useful where requests and/or responses are streamed.
+         */
+        Pusher.create = function create(rpcImpl, requestDelimited, responseDelimited) {
+            return new this(rpcImpl, requestDelimited, responseDelimited);
+        };
 
-    /**
-     * Encodes the specified PushRequest message. Does not implicitly {@link logproto.PushRequest.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {logproto.IPushRequest} message PushRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    PushRequest.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.streams != null && message.streams.length) {
-        for (var i = 0; i < message.streams.length; ++i) {
-          $root.logproto.Stream.encode(
-            message.streams[i],
-            writer.uint32(/* id 1, wireType 2 = */ 10).fork()
-          ).ldelim();
+        /**
+         * Callback as used by {@link logproto.Pusher#push}.
+         * @memberof logproto.Pusher
+         * @typedef PushCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.PushResponse} [response] PushResponse
+         */
+
+        /**
+         * Calls Push.
+         * @function push
+         * @memberof logproto.Pusher
+         * @instance
+         * @param {logproto.IPushRequest} request PushRequest message or plain object
+         * @param {logproto.Pusher.PushCallback} callback Node-style callback called with the error, if any, and PushResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Pusher.prototype.push = function push(request, callback) {
+            return this.rpcCall(push, $root.logproto.PushRequest, $root.logproto.PushResponse, request, callback);
+        }, "name", { value: "Push" });
+
+        /**
+         * Calls Push.
+         * @function push
+         * @memberof logproto.Pusher
+         * @instance
+         * @param {logproto.IPushRequest} request PushRequest message or plain object
+         * @returns {Promise<logproto.PushResponse>} Promise
+         * @variation 2
+         */
+
+        return Pusher;
+    })();
+
+    logproto.Querier = (function() {
+
+        /**
+         * Constructs a new Querier service.
+         * @memberof logproto
+         * @classdesc Represents a Querier
+         * @extends $protobuf.rpc.Service
+         * @constructor
+         * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+         * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+         * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+         */
+        function Querier(rpcImpl, requestDelimited, responseDelimited) {
+            $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
         }
-      }
-      return writer;
-    };
 
-    /**
-     * Encodes the specified PushRequest message, length delimited. Does not implicitly {@link logproto.PushRequest.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {logproto.IPushRequest} message PushRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    PushRequest.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
+        (Querier.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Querier;
 
-    /**
-     * Decodes a PushRequest message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.PushRequest} PushRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    PushRequest.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.PushRequest();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            if (!(message.streams && message.streams.length)) {
-              message.streams = [];
+        /**
+         * Creates new Querier service using the specified rpc implementation.
+         * @function create
+         * @memberof logproto.Querier
+         * @static
+         * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+         * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+         * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+         * @returns {Querier} RPC service. Useful where requests and/or responses are streamed.
+         */
+        Querier.create = function create(rpcImpl, requestDelimited, responseDelimited) {
+            return new this(rpcImpl, requestDelimited, responseDelimited);
+        };
+
+        /**
+         * Callback as used by {@link logproto.Querier#query}.
+         * @memberof logproto.Querier
+         * @typedef QueryCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.QueryResponse} [response] QueryResponse
+         */
+
+        /**
+         * Calls Query.
+         * @function query
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.IQueryRequest} request QueryRequest message or plain object
+         * @param {logproto.Querier.QueryCallback} callback Node-style callback called with the error, if any, and QueryResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Querier.prototype.query = function query(request, callback) {
+            return this.rpcCall(query, $root.logproto.QueryRequest, $root.logproto.QueryResponse, request, callback);
+        }, "name", { value: "Query" });
+
+        /**
+         * Calls Query.
+         * @function query
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.IQueryRequest} request QueryRequest message or plain object
+         * @returns {Promise<logproto.QueryResponse>} Promise
+         * @variation 2
+         */
+
+        /**
+         * Callback as used by {@link logproto.Querier#label}.
+         * @memberof logproto.Querier
+         * @typedef LabelCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.LabelResponse} [response] LabelResponse
+         */
+
+        /**
+         * Calls Label.
+         * @function label
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ILabelRequest} request LabelRequest message or plain object
+         * @param {logproto.Querier.LabelCallback} callback Node-style callback called with the error, if any, and LabelResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Querier.prototype.label = function label(request, callback) {
+            return this.rpcCall(label, $root.logproto.LabelRequest, $root.logproto.LabelResponse, request, callback);
+        }, "name", { value: "Label" });
+
+        /**
+         * Calls Label.
+         * @function label
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ILabelRequest} request LabelRequest message or plain object
+         * @returns {Promise<logproto.LabelResponse>} Promise
+         * @variation 2
+         */
+
+        /**
+         * Callback as used by {@link logproto.Querier#tail}.
+         * @memberof logproto.Querier
+         * @typedef TailCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.TailResponse} [response] TailResponse
+         */
+
+        /**
+         * Calls Tail.
+         * @function tail
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ITailRequest} request TailRequest message or plain object
+         * @param {logproto.Querier.TailCallback} callback Node-style callback called with the error, if any, and TailResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Querier.prototype.tail = function tail(request, callback) {
+            return this.rpcCall(tail, $root.logproto.TailRequest, $root.logproto.TailResponse, request, callback);
+        }, "name", { value: "Tail" });
+
+        /**
+         * Calls Tail.
+         * @function tail
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ITailRequest} request TailRequest message or plain object
+         * @returns {Promise<logproto.TailResponse>} Promise
+         * @variation 2
+         */
+
+        /**
+         * Callback as used by {@link logproto.Querier#series}.
+         * @memberof logproto.Querier
+         * @typedef SeriesCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.SeriesResponse} [response] SeriesResponse
+         */
+
+        /**
+         * Calls Series.
+         * @function series
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ISeriesRequest} request SeriesRequest message or plain object
+         * @param {logproto.Querier.SeriesCallback} callback Node-style callback called with the error, if any, and SeriesResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Querier.prototype.series = function series(request, callback) {
+            return this.rpcCall(series, $root.logproto.SeriesRequest, $root.logproto.SeriesResponse, request, callback);
+        }, "name", { value: "Series" });
+
+        /**
+         * Calls Series.
+         * @function series
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ISeriesRequest} request SeriesRequest message or plain object
+         * @returns {Promise<logproto.SeriesResponse>} Promise
+         * @variation 2
+         */
+
+        /**
+         * Callback as used by {@link logproto.Querier#tailersCount}.
+         * @memberof logproto.Querier
+         * @typedef TailersCountCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.TailersCountResponse} [response] TailersCountResponse
+         */
+
+        /**
+         * Calls TailersCount.
+         * @function tailersCount
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ITailersCountRequest} request TailersCountRequest message or plain object
+         * @param {logproto.Querier.TailersCountCallback} callback Node-style callback called with the error, if any, and TailersCountResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Querier.prototype.tailersCount = function tailersCount(request, callback) {
+            return this.rpcCall(tailersCount, $root.logproto.TailersCountRequest, $root.logproto.TailersCountResponse, request, callback);
+        }, "name", { value: "TailersCount" });
+
+        /**
+         * Calls TailersCount.
+         * @function tailersCount
+         * @memberof logproto.Querier
+         * @instance
+         * @param {logproto.ITailersCountRequest} request TailersCountRequest message or plain object
+         * @returns {Promise<logproto.TailersCountResponse>} Promise
+         * @variation 2
+         */
+
+        return Querier;
+    })();
+
+    logproto.Ingester = (function() {
+
+        /**
+         * Constructs a new Ingester service.
+         * @memberof logproto
+         * @classdesc Represents an Ingester
+         * @extends $protobuf.rpc.Service
+         * @constructor
+         * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+         * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+         * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+         */
+        function Ingester(rpcImpl, requestDelimited, responseDelimited) {
+            $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
+        }
+
+        (Ingester.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Ingester;
+
+        /**
+         * Creates new Ingester service using the specified rpc implementation.
+         * @function create
+         * @memberof logproto.Ingester
+         * @static
+         * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+         * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+         * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+         * @returns {Ingester} RPC service. Useful where requests and/or responses are streamed.
+         */
+        Ingester.create = function create(rpcImpl, requestDelimited, responseDelimited) {
+            return new this(rpcImpl, requestDelimited, responseDelimited);
+        };
+
+        /**
+         * Callback as used by {@link logproto.Ingester#transferChunks}.
+         * @memberof logproto.Ingester
+         * @typedef TransferChunksCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {logproto.TransferChunksResponse} [response] TransferChunksResponse
+         */
+
+        /**
+         * Calls TransferChunks.
+         * @function transferChunks
+         * @memberof logproto.Ingester
+         * @instance
+         * @param {logproto.ITimeSeriesChunk} request TimeSeriesChunk message or plain object
+         * @param {logproto.Ingester.TransferChunksCallback} callback Node-style callback called with the error, if any, and TransferChunksResponse
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(Ingester.prototype.transferChunks = function transferChunks(request, callback) {
+            return this.rpcCall(transferChunks, $root.logproto.TimeSeriesChunk, $root.logproto.TransferChunksResponse, request, callback);
+        }, "name", { value: "TransferChunks" });
+
+        /**
+         * Calls TransferChunks.
+         * @function transferChunks
+         * @memberof logproto.Ingester
+         * @instance
+         * @param {logproto.ITimeSeriesChunk} request TimeSeriesChunk message or plain object
+         * @returns {Promise<logproto.TransferChunksResponse>} Promise
+         * @variation 2
+         */
+
+        return Ingester;
+    })();
+
+    logproto.PushRequest = (function() {
+
+        /**
+         * Properties of a PushRequest.
+         * @memberof logproto
+         * @interface IPushRequest
+         * @property {Array.<logproto.IStream>|null} [streams] PushRequest streams
+         */
+
+        /**
+         * Constructs a new PushRequest.
+         * @memberof logproto
+         * @classdesc Represents a PushRequest.
+         * @implements IPushRequest
+         * @constructor
+         * @param {logproto.IPushRequest=} [properties] Properties to set
+         */
+        function PushRequest(properties) {
+            this.streams = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * PushRequest streams.
+         * @member {Array.<logproto.IStream>} streams
+         * @memberof logproto.PushRequest
+         * @instance
+         */
+        PushRequest.prototype.streams = $util.emptyArray;
+
+        /**
+         * Creates a new PushRequest instance using the specified properties.
+         * @function create
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {logproto.IPushRequest=} [properties] Properties to set
+         * @returns {logproto.PushRequest} PushRequest instance
+         */
+        PushRequest.create = function create(properties) {
+            return new PushRequest(properties);
+        };
+
+        /**
+         * Encodes the specified PushRequest message. Does not implicitly {@link logproto.PushRequest.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {logproto.IPushRequest} message PushRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PushRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.streams != null && message.streams.length)
+                for (var i = 0; i < message.streams.length; ++i)
+                    $root.logproto.Stream.encode(message.streams[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified PushRequest message, length delimited. Does not implicitly {@link logproto.PushRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {logproto.IPushRequest} message PushRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PushRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a PushRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.PushRequest} PushRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PushRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.PushRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.streams && message.streams.length))
+                        message.streams = [];
+                    message.streams.push($root.logproto.Stream.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
             }
-            message.streams.push(
-              $root.logproto.Stream.decode(reader, reader.uint32())
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
+            return message;
+        };
 
-    /**
-     * Decodes a PushRequest message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.PushRequest} PushRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    PushRequest.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
+        /**
+         * Decodes a PushRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.PushRequest} PushRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PushRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-    /**
-     * Verifies a PushRequest message.
-     * @function verify
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    PushRequest.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.streams != null && message.hasOwnProperty("streams")) {
-        if (!Array.isArray(message.streams)) {
-          return "streams: array expected";
-        }
-        for (var i = 0; i < message.streams.length; ++i) {
-          var error = $root.logproto.Stream.verify(message.streams[i]);
-          if (error) {
-            return "streams." + error;
-          }
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a PushRequest message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.PushRequest} PushRequest
-     */
-    PushRequest.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.PushRequest) {
-        return object;
-      }
-      var message = new $root.logproto.PushRequest();
-      if (object.streams) {
-        if (!Array.isArray(object.streams)) {
-          throw TypeError(".logproto.PushRequest.streams: array expected");
-        }
-        message.streams = [];
-        for (var i = 0; i < object.streams.length; ++i) {
-          if (typeof object.streams[i] !== "object") {
-            throw TypeError(".logproto.PushRequest.streams: object expected");
-          }
-          message.streams[i] = $root.logproto.Stream.fromObject(
-            object.streams[i]
-          );
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a PushRequest message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.PushRequest
-     * @static
-     * @param {logproto.PushRequest} message PushRequest
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    PushRequest.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.arrays || options.defaults) {
-        object.streams = [];
-      }
-      if (message.streams && message.streams.length) {
-        object.streams = [];
-        for (var j = 0; j < message.streams.length; ++j) {
-          object.streams[j] = $root.logproto.Stream.toObject(
-            message.streams[j],
-            options
-          );
-        }
-      }
-      return object;
-    };
-
-    /**
-     * Converts this PushRequest to JSON.
-     * @function toJSON
-     * @memberof logproto.PushRequest
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    PushRequest.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return PushRequest;
-  })();
-
-  logproto.PushResponse = (function() {
-    /**
-     * Properties of a PushResponse.
-     * @memberof logproto
-     * @interface IPushResponse
-     */
-
-    /**
-     * Constructs a new PushResponse.
-     * @memberof logproto
-     * @classdesc Represents a PushResponse.
-     * @implements IPushResponse
-     * @constructor
-     * @param {logproto.IPushResponse=} [properties] Properties to set
-     */
-    function PushResponse(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * Creates a new PushResponse instance using the specified properties.
-     * @function create
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {logproto.IPushResponse=} [properties] Properties to set
-     * @returns {logproto.PushResponse} PushResponse instance
-     */
-    PushResponse.create = function create(properties) {
-      return new PushResponse(properties);
-    };
-
-    /**
-     * Encodes the specified PushResponse message. Does not implicitly {@link logproto.PushResponse.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {logproto.IPushResponse} message PushResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    PushResponse.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified PushResponse message, length delimited. Does not implicitly {@link logproto.PushResponse.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {logproto.IPushResponse} message PushResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    PushResponse.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a PushResponse message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.PushResponse} PushResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    PushResponse.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.PushResponse();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes a PushResponse message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.PushResponse} PushResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    PushResponse.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a PushResponse message.
-     * @function verify
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    PushResponse.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      return null;
-    };
-
-    /**
-     * Creates a PushResponse message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.PushResponse} PushResponse
-     */
-    PushResponse.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.PushResponse) {
-        return object;
-      }
-      return new $root.logproto.PushResponse();
-    };
-
-    /**
-     * Creates a plain object from a PushResponse message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.PushResponse
-     * @static
-     * @param {logproto.PushResponse} message PushResponse
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    PushResponse.toObject = function toObject() {
-      return {};
-    };
-
-    /**
-     * Converts this PushResponse to JSON.
-     * @function toJSON
-     * @memberof logproto.PushResponse
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    PushResponse.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return PushResponse;
-  })();
-
-  logproto.QueryRequest = (function() {
-    /**
-     * Properties of a QueryRequest.
-     * @memberof logproto
-     * @interface IQueryRequest
-     * @property {string|null} [selector] QueryRequest selector
-     * @property {number|null} [limit] QueryRequest limit
-     * @property {google.protobuf.ITimestamp|null} [start] QueryRequest start
-     * @property {google.protobuf.ITimestamp|null} [end] QueryRequest end
-     * @property {logproto.Direction|null} [direction] QueryRequest direction
-     */
-
-    /**
-     * Constructs a new QueryRequest.
-     * @memberof logproto
-     * @classdesc Represents a QueryRequest.
-     * @implements IQueryRequest
-     * @constructor
-     * @param {logproto.IQueryRequest=} [properties] Properties to set
-     */
-    function QueryRequest(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * QueryRequest selector.
-     * @member {string} selector
-     * @memberof logproto.QueryRequest
-     * @instance
-     */
-    QueryRequest.prototype.selector = "";
-
-    /**
-     * QueryRequest limit.
-     * @member {number} limit
-     * @memberof logproto.QueryRequest
-     * @instance
-     */
-    QueryRequest.prototype.limit = 0;
-
-    /**
-     * QueryRequest start.
-     * @member {google.protobuf.ITimestamp|null|undefined} start
-     * @memberof logproto.QueryRequest
-     * @instance
-     */
-    QueryRequest.prototype.start = null;
-
-    /**
-     * QueryRequest end.
-     * @member {google.protobuf.ITimestamp|null|undefined} end
-     * @memberof logproto.QueryRequest
-     * @instance
-     */
-    QueryRequest.prototype.end = null;
-
-    /**
-     * QueryRequest direction.
-     * @member {logproto.Direction} direction
-     * @memberof logproto.QueryRequest
-     * @instance
-     */
-    QueryRequest.prototype.direction = 0;
-
-    /**
-     * Creates a new QueryRequest instance using the specified properties.
-     * @function create
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {logproto.IQueryRequest=} [properties] Properties to set
-     * @returns {logproto.QueryRequest} QueryRequest instance
-     */
-    QueryRequest.create = function create(properties) {
-      return new QueryRequest(properties);
-    };
-
-    /**
-     * Encodes the specified QueryRequest message. Does not implicitly {@link logproto.QueryRequest.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {logproto.IQueryRequest} message QueryRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    QueryRequest.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.selector != null && message.hasOwnProperty("selector")) {
-        writer.uint32(/* id 1, wireType 2 = */ 10).string(message.selector);
-      }
-      if (message.limit != null && message.hasOwnProperty("limit")) {
-        writer.uint32(/* id 2, wireType 0 = */ 16).uint32(message.limit);
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.start,
-          writer.uint32(/* id 3, wireType 2 = */ 26).fork()
-        ).ldelim();
-      }
-      if (message.end != null && message.hasOwnProperty("end")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.end,
-          writer.uint32(/* id 4, wireType 2 = */ 34).fork()
-        ).ldelim();
-      }
-      if (message.direction != null && message.hasOwnProperty("direction")) {
-        writer.uint32(/* id 5, wireType 0 = */ 40).int32(message.direction);
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified QueryRequest message, length delimited. Does not implicitly {@link logproto.QueryRequest.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {logproto.IQueryRequest} message QueryRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    QueryRequest.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a QueryRequest message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.QueryRequest} QueryRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    QueryRequest.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.QueryRequest();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.selector = reader.string();
-            break;
-          case 2:
-            message.limit = reader.uint32();
-            break;
-          case 3:
-            message.start = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 4:
-            message.end = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 5:
-            message.direction = reader.int32();
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes a QueryRequest message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.QueryRequest} QueryRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    QueryRequest.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a QueryRequest message.
-     * @function verify
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    QueryRequest.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.selector != null && message.hasOwnProperty("selector")) {
-        if (!$util.isString(message.selector)) {
-          return "selector: string expected";
-        }
-      }
-      if (message.limit != null && message.hasOwnProperty("limit")) {
-        if (!$util.isInteger(message.limit)) {
-          return "limit: integer expected";
-        }
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.start);
-        if (error) {
-          return "start." + error;
-        }
-      }
-      if (message.end != null && message.hasOwnProperty("end")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.end);
-        if (error) {
-          return "end." + error;
-        }
-      }
-      if (message.direction != null && message.hasOwnProperty("direction")) {
-        switch (message.direction) {
-          default:
-            return "direction: enum value expected";
-          case 0:
-          case 1:
-            break;
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a QueryRequest message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.QueryRequest} QueryRequest
-     */
-    QueryRequest.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.QueryRequest) {
-        return object;
-      }
-      var message = new $root.logproto.QueryRequest();
-      if (object.selector != null) {
-        message.selector = String(object.selector);
-      }
-      if (object.limit != null) {
-        message.limit = object.limit >>> 0;
-      }
-      if (object.start != null) {
-        if (typeof object.start !== "object") {
-          throw TypeError(".logproto.QueryRequest.start: object expected");
-        }
-        message.start = $root.google.protobuf.Timestamp.fromObject(
-          object.start
-        );
-      }
-      if (object.end != null) {
-        if (typeof object.end !== "object") {
-          throw TypeError(".logproto.QueryRequest.end: object expected");
-        }
-        message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
-      }
-      switch (object.direction) {
-        case "FORWARD":
-        case 0:
-          message.direction = 0;
-          break;
-        case "BACKWARD":
-        case 1:
-          message.direction = 1;
-          break;
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a QueryRequest message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.QueryRequest
-     * @static
-     * @param {logproto.QueryRequest} message QueryRequest
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    QueryRequest.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        object.selector = "";
-        object.limit = 0;
-        object.start = null;
-        object.end = null;
-        object.direction = options.enums === String ? "FORWARD" : 0;
-      }
-      if (message.selector != null && message.hasOwnProperty("selector")) {
-        object.selector = message.selector;
-      }
-      if (message.limit != null && message.hasOwnProperty("limit")) {
-        object.limit = message.limit;
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        object.start = $root.google.protobuf.Timestamp.toObject(
-          message.start,
-          options
-        );
-      }
-      if (message.end != null && message.hasOwnProperty("end")) {
-        object.end = $root.google.protobuf.Timestamp.toObject(
-          message.end,
-          options
-        );
-      }
-      if (message.direction != null && message.hasOwnProperty("direction")) {
-        object.direction =
-          options.enums === String
-            ? $root.logproto.Direction[message.direction]
-            : message.direction;
-      }
-      return object;
-    };
-
-    /**
-     * Converts this QueryRequest to JSON.
-     * @function toJSON
-     * @memberof logproto.QueryRequest
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    QueryRequest.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return QueryRequest;
-  })();
-
-  /**
-   * Direction enum.
-   * @name logproto.Direction
-   * @enum {string}
-   * @property {number} FORWARD=0 FORWARD value
-   * @property {number} BACKWARD=1 BACKWARD value
-   */
-  logproto.Direction = (function() {
-    var valuesById = {};
-    var values = Object.create(valuesById);
-    values[(valuesById[0] = "FORWARD")] = 0;
-    values[(valuesById[1] = "BACKWARD")] = 1;
-    return values;
-  })();
-
-  logproto.QueryResponse = (function() {
-    /**
-     * Properties of a QueryResponse.
-     * @memberof logproto
-     * @interface IQueryResponse
-     * @property {Array.<logproto.IStream>|null} [streams] QueryResponse streams
-     */
-
-    /**
-     * Constructs a new QueryResponse.
-     * @memberof logproto
-     * @classdesc Represents a QueryResponse.
-     * @implements IQueryResponse
-     * @constructor
-     * @param {logproto.IQueryResponse=} [properties] Properties to set
-     */
-    function QueryResponse(properties) {
-      this.streams = [];
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * QueryResponse streams.
-     * @member {Array.<logproto.IStream>} streams
-     * @memberof logproto.QueryResponse
-     * @instance
-     */
-    QueryResponse.prototype.streams = $util.emptyArray;
-
-    /**
-     * Creates a new QueryResponse instance using the specified properties.
-     * @function create
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {logproto.IQueryResponse=} [properties] Properties to set
-     * @returns {logproto.QueryResponse} QueryResponse instance
-     */
-    QueryResponse.create = function create(properties) {
-      return new QueryResponse(properties);
-    };
-
-    /**
-     * Encodes the specified QueryResponse message. Does not implicitly {@link logproto.QueryResponse.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {logproto.IQueryResponse} message QueryResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    QueryResponse.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.streams != null && message.streams.length) {
-        for (var i = 0; i < message.streams.length; ++i) {
-          $root.logproto.Stream.encode(
-            message.streams[i],
-            writer.uint32(/* id 1, wireType 2 = */ 10).fork()
-          ).ldelim();
-        }
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified QueryResponse message, length delimited. Does not implicitly {@link logproto.QueryResponse.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {logproto.IQueryResponse} message QueryResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    QueryResponse.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a QueryResponse message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.QueryResponse} QueryResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    QueryResponse.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.QueryResponse();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            if (!(message.streams && message.streams.length)) {
-              message.streams = [];
+        /**
+         * Verifies a PushRequest message.
+         * @function verify
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        PushRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.streams != null && message.hasOwnProperty("streams")) {
+                if (!Array.isArray(message.streams))
+                    return "streams: array expected";
+                for (var i = 0; i < message.streams.length; ++i) {
+                    var error = $root.logproto.Stream.verify(message.streams[i]);
+                    if (error)
+                        return "streams." + error;
+                }
             }
-            message.streams.push(
-              $root.logproto.Stream.decode(reader, reader.uint32())
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
+            return null;
+        };
 
-    /**
-     * Decodes a QueryResponse message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.QueryResponse} QueryResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    QueryResponse.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a QueryResponse message.
-     * @function verify
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    QueryResponse.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.streams != null && message.hasOwnProperty("streams")) {
-        if (!Array.isArray(message.streams)) {
-          return "streams: array expected";
-        }
-        for (var i = 0; i < message.streams.length; ++i) {
-          var error = $root.logproto.Stream.verify(message.streams[i]);
-          if (error) {
-            return "streams." + error;
-          }
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a QueryResponse message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.QueryResponse} QueryResponse
-     */
-    QueryResponse.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.QueryResponse) {
-        return object;
-      }
-      var message = new $root.logproto.QueryResponse();
-      if (object.streams) {
-        if (!Array.isArray(object.streams)) {
-          throw TypeError(".logproto.QueryResponse.streams: array expected");
-        }
-        message.streams = [];
-        for (var i = 0; i < object.streams.length; ++i) {
-          if (typeof object.streams[i] !== "object") {
-            throw TypeError(".logproto.QueryResponse.streams: object expected");
-          }
-          message.streams[i] = $root.logproto.Stream.fromObject(
-            object.streams[i]
-          );
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a QueryResponse message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.QueryResponse
-     * @static
-     * @param {logproto.QueryResponse} message QueryResponse
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    QueryResponse.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.arrays || options.defaults) {
-        object.streams = [];
-      }
-      if (message.streams && message.streams.length) {
-        object.streams = [];
-        for (var j = 0; j < message.streams.length; ++j) {
-          object.streams[j] = $root.logproto.Stream.toObject(
-            message.streams[j],
-            options
-          );
-        }
-      }
-      return object;
-    };
-
-    /**
-     * Converts this QueryResponse to JSON.
-     * @function toJSON
-     * @memberof logproto.QueryResponse
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    QueryResponse.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return QueryResponse;
-  })();
-
-  logproto.LabelRequest = (function() {
-    /**
-     * Properties of a LabelRequest.
-     * @memberof logproto
-     * @interface ILabelRequest
-     * @property {string|null} [name] LabelRequest name
-     * @property {boolean|null} [values] LabelRequest values
-     * @property {google.protobuf.ITimestamp|null} [start] LabelRequest start
-     * @property {google.protobuf.ITimestamp|null} [end] LabelRequest end
-     */
-
-    /**
-     * Constructs a new LabelRequest.
-     * @memberof logproto
-     * @classdesc Represents a LabelRequest.
-     * @implements ILabelRequest
-     * @constructor
-     * @param {logproto.ILabelRequest=} [properties] Properties to set
-     */
-    function LabelRequest(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * LabelRequest name.
-     * @member {string} name
-     * @memberof logproto.LabelRequest
-     * @instance
-     */
-    LabelRequest.prototype.name = "";
-
-    /**
-     * LabelRequest values.
-     * @member {boolean} values
-     * @memberof logproto.LabelRequest
-     * @instance
-     */
-    LabelRequest.prototype.values = false;
-
-    /**
-     * LabelRequest start.
-     * @member {google.protobuf.ITimestamp|null|undefined} start
-     * @memberof logproto.LabelRequest
-     * @instance
-     */
-    LabelRequest.prototype.start = null;
-
-    /**
-     * LabelRequest end.
-     * @member {google.protobuf.ITimestamp|null|undefined} end
-     * @memberof logproto.LabelRequest
-     * @instance
-     */
-    LabelRequest.prototype.end = null;
-
-    /**
-     * Creates a new LabelRequest instance using the specified properties.
-     * @function create
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {logproto.ILabelRequest=} [properties] Properties to set
-     * @returns {logproto.LabelRequest} LabelRequest instance
-     */
-    LabelRequest.create = function create(properties) {
-      return new LabelRequest(properties);
-    };
-
-    /**
-     * Encodes the specified LabelRequest message. Does not implicitly {@link logproto.LabelRequest.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {logproto.ILabelRequest} message LabelRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    LabelRequest.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.name != null && message.hasOwnProperty("name")) {
-        writer.uint32(/* id 1, wireType 2 = */ 10).string(message.name);
-      }
-      if (message.values != null && message.hasOwnProperty("values")) {
-        writer.uint32(/* id 2, wireType 0 = */ 16).bool(message.values);
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.start,
-          writer.uint32(/* id 3, wireType 2 = */ 26).fork()
-        ).ldelim();
-      }
-      if (message.end != null && message.hasOwnProperty("end")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.end,
-          writer.uint32(/* id 4, wireType 2 = */ 34).fork()
-        ).ldelim();
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified LabelRequest message, length delimited. Does not implicitly {@link logproto.LabelRequest.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {logproto.ILabelRequest} message LabelRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    LabelRequest.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a LabelRequest message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.LabelRequest} LabelRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    LabelRequest.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.LabelRequest();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.name = reader.string();
-            break;
-          case 2:
-            message.values = reader.bool();
-            break;
-          case 3:
-            message.start = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 4:
-            message.end = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes a LabelRequest message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.LabelRequest} LabelRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    LabelRequest.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a LabelRequest message.
-     * @function verify
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    LabelRequest.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.name != null && message.hasOwnProperty("name")) {
-        if (!$util.isString(message.name)) {
-          return "name: string expected";
-        }
-      }
-      if (message.values != null && message.hasOwnProperty("values")) {
-        if (typeof message.values !== "boolean") {
-          return "values: boolean expected";
-        }
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.start);
-        if (error) {
-          return "start." + error;
-        }
-      }
-      if (message.end != null && message.hasOwnProperty("end")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.end);
-        if (error) {
-          return "end." + error;
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a LabelRequest message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.LabelRequest} LabelRequest
-     */
-    LabelRequest.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.LabelRequest) {
-        return object;
-      }
-      var message = new $root.logproto.LabelRequest();
-      if (object.name != null) {
-        message.name = String(object.name);
-      }
-      if (object.values != null) {
-        message.values = Boolean(object.values);
-      }
-      if (object.start != null) {
-        if (typeof object.start !== "object") {
-          throw TypeError(".logproto.LabelRequest.start: object expected");
-        }
-        message.start = $root.google.protobuf.Timestamp.fromObject(
-          object.start
-        );
-      }
-      if (object.end != null) {
-        if (typeof object.end !== "object") {
-          throw TypeError(".logproto.LabelRequest.end: object expected");
-        }
-        message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a LabelRequest message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.LabelRequest
-     * @static
-     * @param {logproto.LabelRequest} message LabelRequest
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    LabelRequest.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        object.name = "";
-        object.values = false;
-        object.start = null;
-        object.end = null;
-      }
-      if (message.name != null && message.hasOwnProperty("name")) {
-        object.name = message.name;
-      }
-      if (message.values != null && message.hasOwnProperty("values")) {
-        object.values = message.values;
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        object.start = $root.google.protobuf.Timestamp.toObject(
-          message.start,
-          options
-        );
-      }
-      if (message.end != null && message.hasOwnProperty("end")) {
-        object.end = $root.google.protobuf.Timestamp.toObject(
-          message.end,
-          options
-        );
-      }
-      return object;
-    };
-
-    /**
-     * Converts this LabelRequest to JSON.
-     * @function toJSON
-     * @memberof logproto.LabelRequest
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    LabelRequest.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return LabelRequest;
-  })();
-
-  logproto.LabelResponse = (function() {
-    /**
-     * Properties of a LabelResponse.
-     * @memberof logproto
-     * @interface ILabelResponse
-     * @property {Array.<string>|null} [values] LabelResponse values
-     */
-
-    /**
-     * Constructs a new LabelResponse.
-     * @memberof logproto
-     * @classdesc Represents a LabelResponse.
-     * @implements ILabelResponse
-     * @constructor
-     * @param {logproto.ILabelResponse=} [properties] Properties to set
-     */
-    function LabelResponse(properties) {
-      this.values = [];
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * LabelResponse values.
-     * @member {Array.<string>} values
-     * @memberof logproto.LabelResponse
-     * @instance
-     */
-    LabelResponse.prototype.values = $util.emptyArray;
-
-    /**
-     * Creates a new LabelResponse instance using the specified properties.
-     * @function create
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {logproto.ILabelResponse=} [properties] Properties to set
-     * @returns {logproto.LabelResponse} LabelResponse instance
-     */
-    LabelResponse.create = function create(properties) {
-      return new LabelResponse(properties);
-    };
-
-    /**
-     * Encodes the specified LabelResponse message. Does not implicitly {@link logproto.LabelResponse.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {logproto.ILabelResponse} message LabelResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    LabelResponse.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.values != null && message.values.length) {
-        for (var i = 0; i < message.values.length; ++i) {
-          writer.uint32(/* id 1, wireType 2 = */ 10).string(message.values[i]);
-        }
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified LabelResponse message, length delimited. Does not implicitly {@link logproto.LabelResponse.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {logproto.ILabelResponse} message LabelResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    LabelResponse.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a LabelResponse message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.LabelResponse} LabelResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    LabelResponse.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.LabelResponse();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            if (!(message.values && message.values.length)) {
-              message.values = [];
+        /**
+         * Creates a PushRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.PushRequest} PushRequest
+         */
+        PushRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.PushRequest)
+                return object;
+            var message = new $root.logproto.PushRequest();
+            if (object.streams) {
+                if (!Array.isArray(object.streams))
+                    throw TypeError(".logproto.PushRequest.streams: array expected");
+                message.streams = [];
+                for (var i = 0; i < object.streams.length; ++i) {
+                    if (typeof object.streams[i] !== "object")
+                        throw TypeError(".logproto.PushRequest.streams: object expected");
+                    message.streams[i] = $root.logproto.Stream.fromObject(object.streams[i]);
+                }
             }
-            message.values.push(reader.string());
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
+            return message;
+        };
 
-    /**
-     * Decodes a LabelResponse message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.LabelResponse} LabelResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    LabelResponse.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a LabelResponse message.
-     * @function verify
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    LabelResponse.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.values != null && message.hasOwnProperty("values")) {
-        if (!Array.isArray(message.values)) {
-          return "values: array expected";
-        }
-        for (var i = 0; i < message.values.length; ++i) {
-          if (!$util.isString(message.values[i])) {
-            return "values: string[] expected";
-          }
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a LabelResponse message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.LabelResponse} LabelResponse
-     */
-    LabelResponse.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.LabelResponse) {
-        return object;
-      }
-      var message = new $root.logproto.LabelResponse();
-      if (object.values) {
-        if (!Array.isArray(object.values)) {
-          throw TypeError(".logproto.LabelResponse.values: array expected");
-        }
-        message.values = [];
-        for (var i = 0; i < object.values.length; ++i) {
-          message.values[i] = String(object.values[i]);
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a LabelResponse message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.LabelResponse
-     * @static
-     * @param {logproto.LabelResponse} message LabelResponse
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    LabelResponse.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.arrays || options.defaults) {
-        object.values = [];
-      }
-      if (message.values && message.values.length) {
-        object.values = [];
-        for (var j = 0; j < message.values.length; ++j) {
-          object.values[j] = message.values[j];
-        }
-      }
-      return object;
-    };
-
-    /**
-     * Converts this LabelResponse to JSON.
-     * @function toJSON
-     * @memberof logproto.LabelResponse
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    LabelResponse.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return LabelResponse;
-  })();
-
-  logproto.Stream = (function() {
-    /**
-     * Properties of a Stream.
-     * @memberof logproto
-     * @interface IStream
-     * @property {string|null} [labels] Stream labels
-     * @property {Array.<logproto.IEntry>|null} [entries] Stream entries
-     */
-
-    /**
-     * Constructs a new Stream.
-     * @memberof logproto
-     * @classdesc Represents a Stream.
-     * @implements IStream
-     * @constructor
-     * @param {logproto.IStream=} [properties] Properties to set
-     */
-    function Stream(properties) {
-      this.entries = [];
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * Stream labels.
-     * @member {string} labels
-     * @memberof logproto.Stream
-     * @instance
-     */
-    Stream.prototype.labels = "";
-
-    /**
-     * Stream entries.
-     * @member {Array.<logproto.IEntry>} entries
-     * @memberof logproto.Stream
-     * @instance
-     */
-    Stream.prototype.entries = $util.emptyArray;
-
-    /**
-     * Creates a new Stream instance using the specified properties.
-     * @function create
-     * @memberof logproto.Stream
-     * @static
-     * @param {logproto.IStream=} [properties] Properties to set
-     * @returns {logproto.Stream} Stream instance
-     */
-    Stream.create = function create(properties) {
-      return new Stream(properties);
-    };
-
-    /**
-     * Encodes the specified Stream message. Does not implicitly {@link logproto.Stream.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.Stream
-     * @static
-     * @param {logproto.IStream} message Stream message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    Stream.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        writer.uint32(/* id 1, wireType 2 = */ 10).string(message.labels);
-      }
-      if (message.entries != null && message.entries.length) {
-        for (var i = 0; i < message.entries.length; ++i) {
-          $root.logproto.Entry.encode(
-            message.entries[i],
-            writer.uint32(/* id 2, wireType 2 = */ 18).fork()
-          ).ldelim();
-        }
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified Stream message, length delimited. Does not implicitly {@link logproto.Stream.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.Stream
-     * @static
-     * @param {logproto.IStream} message Stream message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    Stream.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a Stream message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.Stream
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.Stream} Stream
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    Stream.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.Stream();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.labels = reader.string();
-            break;
-          case 2:
-            if (!(message.entries && message.entries.length)) {
-              message.entries = [];
+        /**
+         * Creates a plain object from a PushRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.PushRequest
+         * @static
+         * @param {logproto.PushRequest} message PushRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        PushRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.streams = [];
+            if (message.streams && message.streams.length) {
+                object.streams = [];
+                for (var j = 0; j < message.streams.length; ++j)
+                    object.streams[j] = $root.logproto.Stream.toObject(message.streams[j], options);
             }
-            message.entries.push(
-              $root.logproto.Entry.decode(reader, reader.uint32())
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
+            return object;
+        };
+
+        /**
+         * Converts this PushRequest to JSON.
+         * @function toJSON
+         * @memberof logproto.PushRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        PushRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return PushRequest;
+    })();
+
+    logproto.PushResponse = (function() {
+
+        /**
+         * Properties of a PushResponse.
+         * @memberof logproto
+         * @interface IPushResponse
+         */
+
+        /**
+         * Constructs a new PushResponse.
+         * @memberof logproto
+         * @classdesc Represents a PushResponse.
+         * @implements IPushResponse
+         * @constructor
+         * @param {logproto.IPushResponse=} [properties] Properties to set
+         */
+        function PushResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return message;
-    };
 
-    /**
-     * Decodes a Stream message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.Stream
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.Stream} Stream
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    Stream.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
+        /**
+         * Creates a new PushResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {logproto.IPushResponse=} [properties] Properties to set
+         * @returns {logproto.PushResponse} PushResponse instance
+         */
+        PushResponse.create = function create(properties) {
+            return new PushResponse(properties);
+        };
 
-    /**
-     * Verifies a Stream message.
-     * @function verify
-     * @memberof logproto.Stream
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    Stream.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        if (!$util.isString(message.labels)) {
-          return "labels: string expected";
-        }
-      }
-      if (message.entries != null && message.hasOwnProperty("entries")) {
-        if (!Array.isArray(message.entries)) {
-          return "entries: array expected";
-        }
-        for (var i = 0; i < message.entries.length; ++i) {
-          var error = $root.logproto.Entry.verify(message.entries[i]);
-          if (error) {
-            return "entries." + error;
-          }
-        }
-      }
-      return null;
-    };
+        /**
+         * Encodes the specified PushResponse message. Does not implicitly {@link logproto.PushResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {logproto.IPushResponse} message PushResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PushResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            return writer;
+        };
 
-    /**
-     * Creates a Stream message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.Stream
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.Stream} Stream
-     */
-    Stream.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.Stream) {
-        return object;
-      }
-      var message = new $root.logproto.Stream();
-      if (object.labels != null) {
-        message.labels = String(object.labels);
-      }
-      if (object.entries) {
-        if (!Array.isArray(object.entries)) {
-          throw TypeError(".logproto.Stream.entries: array expected");
-        }
-        message.entries = [];
-        for (var i = 0; i < object.entries.length; ++i) {
-          if (typeof object.entries[i] !== "object") {
-            throw TypeError(".logproto.Stream.entries: object expected");
-          }
-          message.entries[i] = $root.logproto.Entry.fromObject(
-            object.entries[i]
-          );
-        }
-      }
-      return message;
-    };
+        /**
+         * Encodes the specified PushResponse message, length delimited. Does not implicitly {@link logproto.PushResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {logproto.IPushResponse} message PushResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PushResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-    /**
-     * Creates a plain object from a Stream message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.Stream
-     * @static
-     * @param {logproto.Stream} message Stream
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    Stream.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.arrays || options.defaults) {
-        object.entries = [];
-      }
-      if (options.defaults) {
-        object.labels = "";
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        object.labels = message.labels;
-      }
-      if (message.entries && message.entries.length) {
-        object.entries = [];
-        for (var j = 0; j < message.entries.length; ++j) {
-          object.entries[j] = $root.logproto.Entry.toObject(
-            message.entries[j],
-            options
-          );
-        }
-      }
-      return object;
-    };
-
-    /**
-     * Converts this Stream to JSON.
-     * @function toJSON
-     * @memberof logproto.Stream
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    Stream.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return Stream;
-  })();
-
-  logproto.Entry = (function() {
-    /**
-     * Properties of an Entry.
-     * @memberof logproto
-     * @interface IEntry
-     * @property {google.protobuf.ITimestamp|null} [timestamp] Entry timestamp
-     * @property {string|null} [line] Entry line
-     */
-
-    /**
-     * Constructs a new Entry.
-     * @memberof logproto
-     * @classdesc Represents an Entry.
-     * @implements IEntry
-     * @constructor
-     * @param {logproto.IEntry=} [properties] Properties to set
-     */
-    function Entry(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * Entry timestamp.
-     * @member {google.protobuf.ITimestamp|null|undefined} timestamp
-     * @memberof logproto.Entry
-     * @instance
-     */
-    Entry.prototype.timestamp = null;
-
-    /**
-     * Entry line.
-     * @member {string} line
-     * @memberof logproto.Entry
-     * @instance
-     */
-    Entry.prototype.line = "";
-
-    /**
-     * Creates a new Entry instance using the specified properties.
-     * @function create
-     * @memberof logproto.Entry
-     * @static
-     * @param {logproto.IEntry=} [properties] Properties to set
-     * @returns {logproto.Entry} Entry instance
-     */
-    Entry.create = function create(properties) {
-      return new Entry(properties);
-    };
-
-    /**
-     * Encodes the specified Entry message. Does not implicitly {@link logproto.Entry.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.Entry
-     * @static
-     * @param {logproto.IEntry} message Entry message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    Entry.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.timestamp != null && message.hasOwnProperty("timestamp")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.timestamp,
-          writer.uint32(/* id 1, wireType 2 = */ 10).fork()
-        ).ldelim();
-      }
-      if (message.line != null && message.hasOwnProperty("line")) {
-        writer.uint32(/* id 2, wireType 2 = */ 18).string(message.line);
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified Entry message, length delimited. Does not implicitly {@link logproto.Entry.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.Entry
-     * @static
-     * @param {logproto.IEntry} message Entry message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    Entry.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes an Entry message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.Entry
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.Entry} Entry
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    Entry.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.Entry();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.timestamp = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 2:
-            message.line = reader.string();
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes an Entry message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.Entry
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.Entry} Entry
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    Entry.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies an Entry message.
-     * @function verify
-     * @memberof logproto.Entry
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    Entry.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.timestamp != null && message.hasOwnProperty("timestamp")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.timestamp);
-        if (error) {
-          return "timestamp." + error;
-        }
-      }
-      if (message.line != null && message.hasOwnProperty("line")) {
-        if (!$util.isString(message.line)) {
-          return "line: string expected";
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates an Entry message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.Entry
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.Entry} Entry
-     */
-    Entry.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.Entry) {
-        return object;
-      }
-      var message = new $root.logproto.Entry();
-      if (object.timestamp != null) {
-        if (typeof object.timestamp !== "object") {
-          throw TypeError(".logproto.Entry.timestamp: object expected");
-        }
-        message.timestamp = $root.google.protobuf.Timestamp.fromObject(
-          object.timestamp
-        );
-      }
-      if (object.line != null) {
-        message.line = String(object.line);
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from an Entry message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.Entry
-     * @static
-     * @param {logproto.Entry} message Entry
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    Entry.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        object.timestamp = null;
-        object.line = "";
-      }
-      if (message.timestamp != null && message.hasOwnProperty("timestamp")) {
-        object.timestamp = $root.google.protobuf.Timestamp.toObject(
-          message.timestamp,
-          options
-        );
-      }
-      if (message.line != null && message.hasOwnProperty("line")) {
-        object.line = message.line;
-      }
-      return object;
-    };
-
-    /**
-     * Converts this Entry to JSON.
-     * @function toJSON
-     * @memberof logproto.Entry
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    Entry.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return Entry;
-  })();
-
-  logproto.TailRequest = (function() {
-    /**
-     * Properties of a TailRequest.
-     * @memberof logproto
-     * @interface ITailRequest
-     * @property {string|null} [query] TailRequest query
-     * @property {number|null} [delayFor] TailRequest delayFor
-     * @property {number|null} [limit] TailRequest limit
-     * @property {google.protobuf.ITimestamp|null} [start] TailRequest start
-     */
-
-    /**
-     * Constructs a new TailRequest.
-     * @memberof logproto
-     * @classdesc Represents a TailRequest.
-     * @implements ITailRequest
-     * @constructor
-     * @param {logproto.ITailRequest=} [properties] Properties to set
-     */
-    function TailRequest(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * TailRequest query.
-     * @member {string} query
-     * @memberof logproto.TailRequest
-     * @instance
-     */
-    TailRequest.prototype.query = "";
-
-    /**
-     * TailRequest delayFor.
-     * @member {number} delayFor
-     * @memberof logproto.TailRequest
-     * @instance
-     */
-    TailRequest.prototype.delayFor = 0;
-
-    /**
-     * TailRequest limit.
-     * @member {number} limit
-     * @memberof logproto.TailRequest
-     * @instance
-     */
-    TailRequest.prototype.limit = 0;
-
-    /**
-     * TailRequest start.
-     * @member {google.protobuf.ITimestamp|null|undefined} start
-     * @memberof logproto.TailRequest
-     * @instance
-     */
-    TailRequest.prototype.start = null;
-
-    /**
-     * Creates a new TailRequest instance using the specified properties.
-     * @function create
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {logproto.ITailRequest=} [properties] Properties to set
-     * @returns {logproto.TailRequest} TailRequest instance
-     */
-    TailRequest.create = function create(properties) {
-      return new TailRequest(properties);
-    };
-
-    /**
-     * Encodes the specified TailRequest message. Does not implicitly {@link logproto.TailRequest.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {logproto.ITailRequest} message TailRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TailRequest.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.query != null && message.hasOwnProperty("query")) {
-        writer.uint32(/* id 1, wireType 2 = */ 10).string(message.query);
-      }
-      if (message.delayFor != null && message.hasOwnProperty("delayFor")) {
-        writer.uint32(/* id 3, wireType 0 = */ 24).uint32(message.delayFor);
-      }
-      if (message.limit != null && message.hasOwnProperty("limit")) {
-        writer.uint32(/* id 4, wireType 0 = */ 32).uint32(message.limit);
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.start,
-          writer.uint32(/* id 5, wireType 2 = */ 42).fork()
-        ).ldelim();
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified TailRequest message, length delimited. Does not implicitly {@link logproto.TailRequest.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {logproto.ITailRequest} message TailRequest message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TailRequest.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a TailRequest message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.TailRequest} TailRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TailRequest.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.TailRequest();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.query = reader.string();
-            break;
-          case 3:
-            message.delayFor = reader.uint32();
-            break;
-          case 4:
-            message.limit = reader.uint32();
-            break;
-          case 5:
-            message.start = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes a TailRequest message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.TailRequest} TailRequest
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TailRequest.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a TailRequest message.
-     * @function verify
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    TailRequest.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.query != null && message.hasOwnProperty("query")) {
-        if (!$util.isString(message.query)) {
-          return "query: string expected";
-        }
-      }
-      if (message.delayFor != null && message.hasOwnProperty("delayFor")) {
-        if (!$util.isInteger(message.delayFor)) {
-          return "delayFor: integer expected";
-        }
-      }
-      if (message.limit != null && message.hasOwnProperty("limit")) {
-        if (!$util.isInteger(message.limit)) {
-          return "limit: integer expected";
-        }
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.start);
-        if (error) {
-          return "start." + error;
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a TailRequest message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.TailRequest} TailRequest
-     */
-    TailRequest.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.TailRequest) {
-        return object;
-      }
-      var message = new $root.logproto.TailRequest();
-      if (object.query != null) {
-        message.query = String(object.query);
-      }
-      if (object.delayFor != null) {
-        message.delayFor = object.delayFor >>> 0;
-      }
-      if (object.limit != null) {
-        message.limit = object.limit >>> 0;
-      }
-      if (object.start != null) {
-        if (typeof object.start !== "object") {
-          throw TypeError(".logproto.TailRequest.start: object expected");
-        }
-        message.start = $root.google.protobuf.Timestamp.fromObject(
-          object.start
-        );
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a TailRequest message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.TailRequest
-     * @static
-     * @param {logproto.TailRequest} message TailRequest
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    TailRequest.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        object.query = "";
-        object.delayFor = 0;
-        object.limit = 0;
-        object.start = null;
-      }
-      if (message.query != null && message.hasOwnProperty("query")) {
-        object.query = message.query;
-      }
-      if (message.delayFor != null && message.hasOwnProperty("delayFor")) {
-        object.delayFor = message.delayFor;
-      }
-      if (message.limit != null && message.hasOwnProperty("limit")) {
-        object.limit = message.limit;
-      }
-      if (message.start != null && message.hasOwnProperty("start")) {
-        object.start = $root.google.protobuf.Timestamp.toObject(
-          message.start,
-          options
-        );
-      }
-      return object;
-    };
-
-    /**
-     * Converts this TailRequest to JSON.
-     * @function toJSON
-     * @memberof logproto.TailRequest
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    TailRequest.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return TailRequest;
-  })();
-
-  logproto.TailResponse = (function() {
-    /**
-     * Properties of a TailResponse.
-     * @memberof logproto
-     * @interface ITailResponse
-     * @property {logproto.IStream|null} [stream] TailResponse stream
-     * @property {Array.<logproto.IDroppedStream>|null} [droppedStreams] TailResponse droppedStreams
-     */
-
-    /**
-     * Constructs a new TailResponse.
-     * @memberof logproto
-     * @classdesc Represents a TailResponse.
-     * @implements ITailResponse
-     * @constructor
-     * @param {logproto.ITailResponse=} [properties] Properties to set
-     */
-    function TailResponse(properties) {
-      this.droppedStreams = [];
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * TailResponse stream.
-     * @member {logproto.IStream|null|undefined} stream
-     * @memberof logproto.TailResponse
-     * @instance
-     */
-    TailResponse.prototype.stream = null;
-
-    /**
-     * TailResponse droppedStreams.
-     * @member {Array.<logproto.IDroppedStream>} droppedStreams
-     * @memberof logproto.TailResponse
-     * @instance
-     */
-    TailResponse.prototype.droppedStreams = $util.emptyArray;
-
-    /**
-     * Creates a new TailResponse instance using the specified properties.
-     * @function create
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {logproto.ITailResponse=} [properties] Properties to set
-     * @returns {logproto.TailResponse} TailResponse instance
-     */
-    TailResponse.create = function create(properties) {
-      return new TailResponse(properties);
-    };
-
-    /**
-     * Encodes the specified TailResponse message. Does not implicitly {@link logproto.TailResponse.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {logproto.ITailResponse} message TailResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TailResponse.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.stream != null && message.hasOwnProperty("stream")) {
-        $root.logproto.Stream.encode(
-          message.stream,
-          writer.uint32(/* id 1, wireType 2 = */ 10).fork()
-        ).ldelim();
-      }
-      if (message.droppedStreams != null && message.droppedStreams.length) {
-        for (var i = 0; i < message.droppedStreams.length; ++i) {
-          $root.logproto.DroppedStream.encode(
-            message.droppedStreams[i],
-            writer.uint32(/* id 2, wireType 2 = */ 18).fork()
-          ).ldelim();
-        }
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified TailResponse message, length delimited. Does not implicitly {@link logproto.TailResponse.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {logproto.ITailResponse} message TailResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TailResponse.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a TailResponse message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.TailResponse} TailResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TailResponse.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.TailResponse();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.stream = $root.logproto.Stream.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 2:
-            if (!(message.droppedStreams && message.droppedStreams.length)) {
-              message.droppedStreams = [];
+        /**
+         * Decodes a PushResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.PushResponse} PushResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PushResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.PushResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
             }
-            message.droppedStreams.push(
-              $root.logproto.DroppedStream.decode(reader, reader.uint32())
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
+            return message;
+        };
+
+        /**
+         * Decodes a PushResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.PushResponse} PushResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PushResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a PushResponse message.
+         * @function verify
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        PushResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            return null;
+        };
+
+        /**
+         * Creates a PushResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.PushResponse} PushResponse
+         */
+        PushResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.PushResponse)
+                return object;
+            return new $root.logproto.PushResponse();
+        };
+
+        /**
+         * Creates a plain object from a PushResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.PushResponse
+         * @static
+         * @param {logproto.PushResponse} message PushResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        PushResponse.toObject = function toObject() {
+            return {};
+        };
+
+        /**
+         * Converts this PushResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.PushResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        PushResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return PushResponse;
+    })();
+
+    logproto.QueryRequest = (function() {
+
+        /**
+         * Properties of a QueryRequest.
+         * @memberof logproto
+         * @interface IQueryRequest
+         * @property {string|null} [selector] QueryRequest selector
+         * @property {number|null} [limit] QueryRequest limit
+         * @property {google.protobuf.ITimestamp|null} [start] QueryRequest start
+         * @property {google.protobuf.ITimestamp|null} [end] QueryRequest end
+         * @property {logproto.Direction|null} [direction] QueryRequest direction
+         */
+
+        /**
+         * Constructs a new QueryRequest.
+         * @memberof logproto
+         * @classdesc Represents a QueryRequest.
+         * @implements IQueryRequest
+         * @constructor
+         * @param {logproto.IQueryRequest=} [properties] Properties to set
+         */
+        function QueryRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return message;
-    };
 
-    /**
-     * Decodes a TailResponse message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.TailResponse} TailResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TailResponse.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
+        /**
+         * QueryRequest selector.
+         * @member {string} selector
+         * @memberof logproto.QueryRequest
+         * @instance
+         */
+        QueryRequest.prototype.selector = "";
 
-    /**
-     * Verifies a TailResponse message.
-     * @function verify
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    TailResponse.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.stream != null && message.hasOwnProperty("stream")) {
-        var error = $root.logproto.Stream.verify(message.stream);
-        if (error) {
-          return "stream." + error;
-        }
-      }
-      if (
-        message.droppedStreams != null &&
-        message.hasOwnProperty("droppedStreams")
-      ) {
-        if (!Array.isArray(message.droppedStreams)) {
-          return "droppedStreams: array expected";
-        }
-        for (var i = 0; i < message.droppedStreams.length; ++i) {
-          var error = $root.logproto.DroppedStream.verify(
-            message.droppedStreams[i]
-          );
-          if (error) {
-            return "droppedStreams." + error;
-          }
-        }
-      }
-      return null;
-    };
+        /**
+         * QueryRequest limit.
+         * @member {number} limit
+         * @memberof logproto.QueryRequest
+         * @instance
+         */
+        QueryRequest.prototype.limit = 0;
 
-    /**
-     * Creates a TailResponse message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.TailResponse} TailResponse
-     */
-    TailResponse.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.TailResponse) {
-        return object;
-      }
-      var message = new $root.logproto.TailResponse();
-      if (object.stream != null) {
-        if (typeof object.stream !== "object") {
-          throw TypeError(".logproto.TailResponse.stream: object expected");
-        }
-        message.stream = $root.logproto.Stream.fromObject(object.stream);
-      }
-      if (object.droppedStreams) {
-        if (!Array.isArray(object.droppedStreams)) {
-          throw TypeError(
-            ".logproto.TailResponse.droppedStreams: array expected"
-          );
-        }
-        message.droppedStreams = [];
-        for (var i = 0; i < object.droppedStreams.length; ++i) {
-          if (typeof object.droppedStreams[i] !== "object") {
-            throw TypeError(
-              ".logproto.TailResponse.droppedStreams: object expected"
-            );
-          }
-          message.droppedStreams[i] = $root.logproto.DroppedStream.fromObject(
-            object.droppedStreams[i]
-          );
-        }
-      }
-      return message;
-    };
+        /**
+         * QueryRequest start.
+         * @member {google.protobuf.ITimestamp|null|undefined} start
+         * @memberof logproto.QueryRequest
+         * @instance
+         */
+        QueryRequest.prototype.start = null;
 
-    /**
-     * Creates a plain object from a TailResponse message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.TailResponse
-     * @static
-     * @param {logproto.TailResponse} message TailResponse
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    TailResponse.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.arrays || options.defaults) {
-        object.droppedStreams = [];
-      }
-      if (options.defaults) {
-        object.stream = null;
-      }
-      if (message.stream != null && message.hasOwnProperty("stream")) {
-        object.stream = $root.logproto.Stream.toObject(message.stream, options);
-      }
-      if (message.droppedStreams && message.droppedStreams.length) {
-        object.droppedStreams = [];
-        for (var j = 0; j < message.droppedStreams.length; ++j) {
-          object.droppedStreams[j] = $root.logproto.DroppedStream.toObject(
-            message.droppedStreams[j],
-            options
-          );
-        }
-      }
-      return object;
-    };
+        /**
+         * QueryRequest end.
+         * @member {google.protobuf.ITimestamp|null|undefined} end
+         * @memberof logproto.QueryRequest
+         * @instance
+         */
+        QueryRequest.prototype.end = null;
 
-    /**
-     * Converts this TailResponse to JSON.
-     * @function toJSON
-     * @memberof logproto.TailResponse
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    TailResponse.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
+        /**
+         * QueryRequest direction.
+         * @member {logproto.Direction} direction
+         * @memberof logproto.QueryRequest
+         * @instance
+         */
+        QueryRequest.prototype.direction = 0;
 
-    return TailResponse;
-  })();
+        /**
+         * Creates a new QueryRequest instance using the specified properties.
+         * @function create
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {logproto.IQueryRequest=} [properties] Properties to set
+         * @returns {logproto.QueryRequest} QueryRequest instance
+         */
+        QueryRequest.create = function create(properties) {
+            return new QueryRequest(properties);
+        };
 
-  logproto.DroppedStream = (function() {
-    /**
-     * Properties of a DroppedStream.
-     * @memberof logproto
-     * @interface IDroppedStream
-     * @property {google.protobuf.ITimestamp|null} [from] DroppedStream from
-     * @property {google.protobuf.ITimestamp|null} [to] DroppedStream to
-     * @property {string|null} [labels] DroppedStream labels
-     */
+        /**
+         * Encodes the specified QueryRequest message. Does not implicitly {@link logproto.QueryRequest.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {logproto.IQueryRequest} message QueryRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QueryRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.selector != null && message.hasOwnProperty("selector"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.selector);
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.limit);
+            if (message.start != null && message.hasOwnProperty("start"))
+                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.end != null && message.hasOwnProperty("end"))
+                $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            if (message.direction != null && message.hasOwnProperty("direction"))
+                writer.uint32(/* id 5, wireType 0 =*/40).int32(message.direction);
+            return writer;
+        };
 
-    /**
-     * Constructs a new DroppedStream.
-     * @memberof logproto
-     * @classdesc Represents a DroppedStream.
-     * @implements IDroppedStream
-     * @constructor
-     * @param {logproto.IDroppedStream=} [properties] Properties to set
-     */
-    function DroppedStream(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
+        /**
+         * Encodes the specified QueryRequest message, length delimited. Does not implicitly {@link logproto.QueryRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {logproto.IQueryRequest} message QueryRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QueryRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-    /**
-     * DroppedStream from.
-     * @member {google.protobuf.ITimestamp|null|undefined} from
-     * @memberof logproto.DroppedStream
-     * @instance
-     */
-    DroppedStream.prototype.from = null;
-
-    /**
-     * DroppedStream to.
-     * @member {google.protobuf.ITimestamp|null|undefined} to
-     * @memberof logproto.DroppedStream
-     * @instance
-     */
-    DroppedStream.prototype.to = null;
-
-    /**
-     * DroppedStream labels.
-     * @member {string} labels
-     * @memberof logproto.DroppedStream
-     * @instance
-     */
-    DroppedStream.prototype.labels = "";
-
-    /**
-     * Creates a new DroppedStream instance using the specified properties.
-     * @function create
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {logproto.IDroppedStream=} [properties] Properties to set
-     * @returns {logproto.DroppedStream} DroppedStream instance
-     */
-    DroppedStream.create = function create(properties) {
-      return new DroppedStream(properties);
-    };
-
-    /**
-     * Encodes the specified DroppedStream message. Does not implicitly {@link logproto.DroppedStream.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {logproto.IDroppedStream} message DroppedStream message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    DroppedStream.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.from != null && message.hasOwnProperty("from")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.from,
-          writer.uint32(/* id 1, wireType 2 = */ 10).fork()
-        ).ldelim();
-      }
-      if (message.to != null && message.hasOwnProperty("to")) {
-        $root.google.protobuf.Timestamp.encode(
-          message.to,
-          writer.uint32(/* id 2, wireType 2 = */ 18).fork()
-        ).ldelim();
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        writer.uint32(/* id 3, wireType 2 = */ 26).string(message.labels);
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified DroppedStream message, length delimited. Does not implicitly {@link logproto.DroppedStream.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {logproto.IDroppedStream} message DroppedStream message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    DroppedStream.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a DroppedStream message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.DroppedStream} DroppedStream
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    DroppedStream.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.DroppedStream();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.from = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 2:
-            message.to = $root.google.protobuf.Timestamp.decode(
-              reader,
-              reader.uint32()
-            );
-            break;
-          case 3:
-            message.labels = reader.string();
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes a DroppedStream message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.DroppedStream} DroppedStream
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    DroppedStream.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a DroppedStream message.
-     * @function verify
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    DroppedStream.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.from != null && message.hasOwnProperty("from")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.from);
-        if (error) {
-          return "from." + error;
-        }
-      }
-      if (message.to != null && message.hasOwnProperty("to")) {
-        var error = $root.google.protobuf.Timestamp.verify(message.to);
-        if (error) {
-          return "to." + error;
-        }
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        if (!$util.isString(message.labels)) {
-          return "labels: string expected";
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a DroppedStream message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.DroppedStream} DroppedStream
-     */
-    DroppedStream.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.DroppedStream) {
-        return object;
-      }
-      var message = new $root.logproto.DroppedStream();
-      if (object.from != null) {
-        if (typeof object.from !== "object") {
-          throw TypeError(".logproto.DroppedStream.from: object expected");
-        }
-        message.from = $root.google.protobuf.Timestamp.fromObject(object.from);
-      }
-      if (object.to != null) {
-        if (typeof object.to !== "object") {
-          throw TypeError(".logproto.DroppedStream.to: object expected");
-        }
-        message.to = $root.google.protobuf.Timestamp.fromObject(object.to);
-      }
-      if (object.labels != null) {
-        message.labels = String(object.labels);
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a DroppedStream message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.DroppedStream
-     * @static
-     * @param {logproto.DroppedStream} message DroppedStream
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    DroppedStream.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        object.from = null;
-        object.to = null;
-        object.labels = "";
-      }
-      if (message.from != null && message.hasOwnProperty("from")) {
-        object.from = $root.google.protobuf.Timestamp.toObject(
-          message.from,
-          options
-        );
-      }
-      if (message.to != null && message.hasOwnProperty("to")) {
-        object.to = $root.google.protobuf.Timestamp.toObject(
-          message.to,
-          options
-        );
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        object.labels = message.labels;
-      }
-      return object;
-    };
-
-    /**
-     * Converts this DroppedStream to JSON.
-     * @function toJSON
-     * @memberof logproto.DroppedStream
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    DroppedStream.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return DroppedStream;
-  })();
-
-  logproto.TimeSeriesChunk = (function() {
-    /**
-     * Properties of a TimeSeriesChunk.
-     * @memberof logproto
-     * @interface ITimeSeriesChunk
-     * @property {string|null} [fromIngesterId] TimeSeriesChunk fromIngesterId
-     * @property {string|null} [userId] TimeSeriesChunk userId
-     * @property {Array.<logproto.ILabelPair>|null} [labels] TimeSeriesChunk labels
-     * @property {Array.<logproto.IChunk>|null} [chunks] TimeSeriesChunk chunks
-     */
-
-    /**
-     * Constructs a new TimeSeriesChunk.
-     * @memberof logproto
-     * @classdesc Represents a TimeSeriesChunk.
-     * @implements ITimeSeriesChunk
-     * @constructor
-     * @param {logproto.ITimeSeriesChunk=} [properties] Properties to set
-     */
-    function TimeSeriesChunk(properties) {
-      this.labels = [];
-      this.chunks = [];
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * TimeSeriesChunk fromIngesterId.
-     * @member {string} fromIngesterId
-     * @memberof logproto.TimeSeriesChunk
-     * @instance
-     */
-    TimeSeriesChunk.prototype.fromIngesterId = "";
-
-    /**
-     * TimeSeriesChunk userId.
-     * @member {string} userId
-     * @memberof logproto.TimeSeriesChunk
-     * @instance
-     */
-    TimeSeriesChunk.prototype.userId = "";
-
-    /**
-     * TimeSeriesChunk labels.
-     * @member {Array.<logproto.ILabelPair>} labels
-     * @memberof logproto.TimeSeriesChunk
-     * @instance
-     */
-    TimeSeriesChunk.prototype.labels = $util.emptyArray;
-
-    /**
-     * TimeSeriesChunk chunks.
-     * @member {Array.<logproto.IChunk>} chunks
-     * @memberof logproto.TimeSeriesChunk
-     * @instance
-     */
-    TimeSeriesChunk.prototype.chunks = $util.emptyArray;
-
-    /**
-     * Creates a new TimeSeriesChunk instance using the specified properties.
-     * @function create
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {logproto.ITimeSeriesChunk=} [properties] Properties to set
-     * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk instance
-     */
-    TimeSeriesChunk.create = function create(properties) {
-      return new TimeSeriesChunk(properties);
-    };
-
-    /**
-     * Encodes the specified TimeSeriesChunk message. Does not implicitly {@link logproto.TimeSeriesChunk.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {logproto.ITimeSeriesChunk} message TimeSeriesChunk message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TimeSeriesChunk.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (
-        message.fromIngesterId != null &&
-        message.hasOwnProperty("fromIngesterId")
-      ) {
-        writer
-          .uint32(/* id 1, wireType 2 = */ 10)
-          .string(message.fromIngesterId);
-      }
-      if (message.userId != null && message.hasOwnProperty("userId")) {
-        writer.uint32(/* id 2, wireType 2 = */ 18).string(message.userId);
-      }
-      if (message.labels != null && message.labels.length) {
-        for (var i = 0; i < message.labels.length; ++i) {
-          $root.logproto.LabelPair.encode(
-            message.labels[i],
-            writer.uint32(/* id 3, wireType 2 = */ 26).fork()
-          ).ldelim();
-        }
-      }
-      if (message.chunks != null && message.chunks.length) {
-        for (var i = 0; i < message.chunks.length; ++i) {
-          $root.logproto.Chunk.encode(
-            message.chunks[i],
-            writer.uint32(/* id 4, wireType 2 = */ 34).fork()
-          ).ldelim();
-        }
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified TimeSeriesChunk message, length delimited. Does not implicitly {@link logproto.TimeSeriesChunk.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {logproto.ITimeSeriesChunk} message TimeSeriesChunk message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TimeSeriesChunk.encodeDelimited = function encodeDelimited(
-      message,
-      writer
-    ) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a TimeSeriesChunk message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TimeSeriesChunk.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.TimeSeriesChunk();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.fromIngesterId = reader.string();
-            break;
-          case 2:
-            message.userId = reader.string();
-            break;
-          case 3:
-            if (!(message.labels && message.labels.length)) {
-              message.labels = [];
+        /**
+         * Decodes a QueryRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.QueryRequest} QueryRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QueryRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.QueryRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.selector = reader.string();
+                    break;
+                case 2:
+                    message.limit = reader.uint32();
+                    break;
+                case 3:
+                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 4:
+                    message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 5:
+                    message.direction = reader.int32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
             }
-            message.labels.push(
-              $root.logproto.LabelPair.decode(reader, reader.uint32())
-            );
-            break;
-          case 4:
-            if (!(message.chunks && message.chunks.length)) {
-              message.chunks = [];
+            return message;
+        };
+
+        /**
+         * Decodes a QueryRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.QueryRequest} QueryRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QueryRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QueryRequest message.
+         * @function verify
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QueryRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.selector != null && message.hasOwnProperty("selector"))
+                if (!$util.isString(message.selector))
+                    return "selector: string expected";
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                if (!$util.isInteger(message.limit))
+                    return "limit: integer expected";
+            if (message.start != null && message.hasOwnProperty("start")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.start);
+                if (error)
+                    return "start." + error;
             }
-            message.chunks.push(
-              $root.logproto.Chunk.decode(reader, reader.uint32())
-            );
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
+            if (message.end != null && message.hasOwnProperty("end")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.end);
+                if (error)
+                    return "end." + error;
+            }
+            if (message.direction != null && message.hasOwnProperty("direction"))
+                switch (message.direction) {
+                default:
+                    return "direction: enum value expected";
+                case 0:
+                case 1:
+                    break;
+                }
+            return null;
+        };
+
+        /**
+         * Creates a QueryRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.QueryRequest} QueryRequest
+         */
+        QueryRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.QueryRequest)
+                return object;
+            var message = new $root.logproto.QueryRequest();
+            if (object.selector != null)
+                message.selector = String(object.selector);
+            if (object.limit != null)
+                message.limit = object.limit >>> 0;
+            if (object.start != null) {
+                if (typeof object.start !== "object")
+                    throw TypeError(".logproto.QueryRequest.start: object expected");
+                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
+            }
+            if (object.end != null) {
+                if (typeof object.end !== "object")
+                    throw TypeError(".logproto.QueryRequest.end: object expected");
+                message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
+            }
+            switch (object.direction) {
+            case "FORWARD":
+            case 0:
+                message.direction = 0;
+                break;
+            case "BACKWARD":
+            case 1:
+                message.direction = 1;
+                break;
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QueryRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.QueryRequest
+         * @static
+         * @param {logproto.QueryRequest} message QueryRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QueryRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.selector = "";
+                object.limit = 0;
+                object.start = null;
+                object.end = null;
+                object.direction = options.enums === String ? "FORWARD" : 0;
+            }
+            if (message.selector != null && message.hasOwnProperty("selector"))
+                object.selector = message.selector;
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                object.limit = message.limit;
+            if (message.start != null && message.hasOwnProperty("start"))
+                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
+            if (message.end != null && message.hasOwnProperty("end"))
+                object.end = $root.google.protobuf.Timestamp.toObject(message.end, options);
+            if (message.direction != null && message.hasOwnProperty("direction"))
+                object.direction = options.enums === String ? $root.logproto.Direction[message.direction] : message.direction;
+            return object;
+        };
+
+        /**
+         * Converts this QueryRequest to JSON.
+         * @function toJSON
+         * @memberof logproto.QueryRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QueryRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QueryRequest;
+    })();
+
+    /**
+     * Direction enum.
+     * @name logproto.Direction
+     * @enum {string}
+     * @property {number} FORWARD=0 FORWARD value
+     * @property {number} BACKWARD=1 BACKWARD value
+     */
+    logproto.Direction = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "FORWARD"] = 0;
+        values[valuesById[1] = "BACKWARD"] = 1;
+        return values;
+    })();
+
+    logproto.QueryResponse = (function() {
+
+        /**
+         * Properties of a QueryResponse.
+         * @memberof logproto
+         * @interface IQueryResponse
+         * @property {Array.<logproto.IStream>|null} [streams] QueryResponse streams
+         */
+
+        /**
+         * Constructs a new QueryResponse.
+         * @memberof logproto
+         * @classdesc Represents a QueryResponse.
+         * @implements IQueryResponse
+         * @constructor
+         * @param {logproto.IQueryResponse=} [properties] Properties to set
+         */
+        function QueryResponse(properties) {
+            this.streams = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return message;
-    };
 
-    /**
-     * Decodes a TimeSeriesChunk message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TimeSeriesChunk.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
+        /**
+         * QueryResponse streams.
+         * @member {Array.<logproto.IStream>} streams
+         * @memberof logproto.QueryResponse
+         * @instance
+         */
+        QueryResponse.prototype.streams = $util.emptyArray;
 
-    /**
-     * Verifies a TimeSeriesChunk message.
-     * @function verify
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    TimeSeriesChunk.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (
-        message.fromIngesterId != null &&
-        message.hasOwnProperty("fromIngesterId")
-      ) {
-        if (!$util.isString(message.fromIngesterId)) {
-          return "fromIngesterId: string expected";
+        /**
+         * Creates a new QueryResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {logproto.IQueryResponse=} [properties] Properties to set
+         * @returns {logproto.QueryResponse} QueryResponse instance
+         */
+        QueryResponse.create = function create(properties) {
+            return new QueryResponse(properties);
+        };
+
+        /**
+         * Encodes the specified QueryResponse message. Does not implicitly {@link logproto.QueryResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {logproto.IQueryResponse} message QueryResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QueryResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.streams != null && message.streams.length)
+                for (var i = 0; i < message.streams.length; ++i)
+                    $root.logproto.Stream.encode(message.streams[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified QueryResponse message, length delimited. Does not implicitly {@link logproto.QueryResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {logproto.IQueryResponse} message QueryResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QueryResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a QueryResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.QueryResponse} QueryResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QueryResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.QueryResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.streams && message.streams.length))
+                        message.streams = [];
+                    message.streams.push($root.logproto.Stream.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a QueryResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.QueryResponse} QueryResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QueryResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QueryResponse message.
+         * @function verify
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QueryResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.streams != null && message.hasOwnProperty("streams")) {
+                if (!Array.isArray(message.streams))
+                    return "streams: array expected";
+                for (var i = 0; i < message.streams.length; ++i) {
+                    var error = $root.logproto.Stream.verify(message.streams[i]);
+                    if (error)
+                        return "streams." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a QueryResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.QueryResponse} QueryResponse
+         */
+        QueryResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.QueryResponse)
+                return object;
+            var message = new $root.logproto.QueryResponse();
+            if (object.streams) {
+                if (!Array.isArray(object.streams))
+                    throw TypeError(".logproto.QueryResponse.streams: array expected");
+                message.streams = [];
+                for (var i = 0; i < object.streams.length; ++i) {
+                    if (typeof object.streams[i] !== "object")
+                        throw TypeError(".logproto.QueryResponse.streams: object expected");
+                    message.streams[i] = $root.logproto.Stream.fromObject(object.streams[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QueryResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.QueryResponse
+         * @static
+         * @param {logproto.QueryResponse} message QueryResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QueryResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.streams = [];
+            if (message.streams && message.streams.length) {
+                object.streams = [];
+                for (var j = 0; j < message.streams.length; ++j)
+                    object.streams[j] = $root.logproto.Stream.toObject(message.streams[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this QueryResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.QueryResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QueryResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QueryResponse;
+    })();
+
+    logproto.LabelRequest = (function() {
+
+        /**
+         * Properties of a LabelRequest.
+         * @memberof logproto
+         * @interface ILabelRequest
+         * @property {string|null} [name] LabelRequest name
+         * @property {boolean|null} [values] LabelRequest values
+         * @property {google.protobuf.ITimestamp|null} [start] LabelRequest start
+         * @property {google.protobuf.ITimestamp|null} [end] LabelRequest end
+         */
+
+        /**
+         * Constructs a new LabelRequest.
+         * @memberof logproto
+         * @classdesc Represents a LabelRequest.
+         * @implements ILabelRequest
+         * @constructor
+         * @param {logproto.ILabelRequest=} [properties] Properties to set
+         */
+        function LabelRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      if (message.userId != null && message.hasOwnProperty("userId")) {
-        if (!$util.isString(message.userId)) {
-          return "userId: string expected";
+
+        /**
+         * LabelRequest name.
+         * @member {string} name
+         * @memberof logproto.LabelRequest
+         * @instance
+         */
+        LabelRequest.prototype.name = "";
+
+        /**
+         * LabelRequest values.
+         * @member {boolean} values
+         * @memberof logproto.LabelRequest
+         * @instance
+         */
+        LabelRequest.prototype.values = false;
+
+        /**
+         * LabelRequest start.
+         * @member {google.protobuf.ITimestamp|null|undefined} start
+         * @memberof logproto.LabelRequest
+         * @instance
+         */
+        LabelRequest.prototype.start = null;
+
+        /**
+         * LabelRequest end.
+         * @member {google.protobuf.ITimestamp|null|undefined} end
+         * @memberof logproto.LabelRequest
+         * @instance
+         */
+        LabelRequest.prototype.end = null;
+
+        /**
+         * Creates a new LabelRequest instance using the specified properties.
+         * @function create
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {logproto.ILabelRequest=} [properties] Properties to set
+         * @returns {logproto.LabelRequest} LabelRequest instance
+         */
+        LabelRequest.create = function create(properties) {
+            return new LabelRequest(properties);
+        };
+
+        /**
+         * Encodes the specified LabelRequest message. Does not implicitly {@link logproto.LabelRequest.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {logproto.ILabelRequest} message LabelRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        LabelRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.name != null && message.hasOwnProperty("name"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+            if (message.values != null && message.hasOwnProperty("values"))
+                writer.uint32(/* id 2, wireType 0 =*/16).bool(message.values);
+            if (message.start != null && message.hasOwnProperty("start"))
+                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.end != null && message.hasOwnProperty("end"))
+                $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified LabelRequest message, length delimited. Does not implicitly {@link logproto.LabelRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {logproto.ILabelRequest} message LabelRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        LabelRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a LabelRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.LabelRequest} LabelRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        LabelRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.LabelRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.name = reader.string();
+                    break;
+                case 2:
+                    message.values = reader.bool();
+                    break;
+                case 3:
+                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 4:
+                    message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a LabelRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.LabelRequest} LabelRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        LabelRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a LabelRequest message.
+         * @function verify
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        LabelRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.name != null && message.hasOwnProperty("name"))
+                if (!$util.isString(message.name))
+                    return "name: string expected";
+            if (message.values != null && message.hasOwnProperty("values"))
+                if (typeof message.values !== "boolean")
+                    return "values: boolean expected";
+            if (message.start != null && message.hasOwnProperty("start")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.start);
+                if (error)
+                    return "start." + error;
+            }
+            if (message.end != null && message.hasOwnProperty("end")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.end);
+                if (error)
+                    return "end." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a LabelRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.LabelRequest} LabelRequest
+         */
+        LabelRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.LabelRequest)
+                return object;
+            var message = new $root.logproto.LabelRequest();
+            if (object.name != null)
+                message.name = String(object.name);
+            if (object.values != null)
+                message.values = Boolean(object.values);
+            if (object.start != null) {
+                if (typeof object.start !== "object")
+                    throw TypeError(".logproto.LabelRequest.start: object expected");
+                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
+            }
+            if (object.end != null) {
+                if (typeof object.end !== "object")
+                    throw TypeError(".logproto.LabelRequest.end: object expected");
+                message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a LabelRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.LabelRequest
+         * @static
+         * @param {logproto.LabelRequest} message LabelRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        LabelRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.name = "";
+                object.values = false;
+                object.start = null;
+                object.end = null;
+            }
+            if (message.name != null && message.hasOwnProperty("name"))
+                object.name = message.name;
+            if (message.values != null && message.hasOwnProperty("values"))
+                object.values = message.values;
+            if (message.start != null && message.hasOwnProperty("start"))
+                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
+            if (message.end != null && message.hasOwnProperty("end"))
+                object.end = $root.google.protobuf.Timestamp.toObject(message.end, options);
+            return object;
+        };
+
+        /**
+         * Converts this LabelRequest to JSON.
+         * @function toJSON
+         * @memberof logproto.LabelRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        LabelRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return LabelRequest;
+    })();
+
+    logproto.LabelResponse = (function() {
+
+        /**
+         * Properties of a LabelResponse.
+         * @memberof logproto
+         * @interface ILabelResponse
+         * @property {Array.<string>|null} [values] LabelResponse values
+         */
+
+        /**
+         * Constructs a new LabelResponse.
+         * @memberof logproto
+         * @classdesc Represents a LabelResponse.
+         * @implements ILabelResponse
+         * @constructor
+         * @param {logproto.ILabelResponse=} [properties] Properties to set
+         */
+        function LabelResponse(properties) {
+            this.values = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      if (message.labels != null && message.hasOwnProperty("labels")) {
-        if (!Array.isArray(message.labels)) {
-          return "labels: array expected";
+
+        /**
+         * LabelResponse values.
+         * @member {Array.<string>} values
+         * @memberof logproto.LabelResponse
+         * @instance
+         */
+        LabelResponse.prototype.values = $util.emptyArray;
+
+        /**
+         * Creates a new LabelResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {logproto.ILabelResponse=} [properties] Properties to set
+         * @returns {logproto.LabelResponse} LabelResponse instance
+         */
+        LabelResponse.create = function create(properties) {
+            return new LabelResponse(properties);
+        };
+
+        /**
+         * Encodes the specified LabelResponse message. Does not implicitly {@link logproto.LabelResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {logproto.ILabelResponse} message LabelResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        LabelResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.values != null && message.values.length)
+                for (var i = 0; i < message.values.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.values[i]);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified LabelResponse message, length delimited. Does not implicitly {@link logproto.LabelResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {logproto.ILabelResponse} message LabelResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        LabelResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a LabelResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.LabelResponse} LabelResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        LabelResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.LabelResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.values && message.values.length))
+                        message.values = [];
+                    message.values.push(reader.string());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a LabelResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.LabelResponse} LabelResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        LabelResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a LabelResponse message.
+         * @function verify
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        LabelResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.values != null && message.hasOwnProperty("values")) {
+                if (!Array.isArray(message.values))
+                    return "values: array expected";
+                for (var i = 0; i < message.values.length; ++i)
+                    if (!$util.isString(message.values[i]))
+                        return "values: string[] expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a LabelResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.LabelResponse} LabelResponse
+         */
+        LabelResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.LabelResponse)
+                return object;
+            var message = new $root.logproto.LabelResponse();
+            if (object.values) {
+                if (!Array.isArray(object.values))
+                    throw TypeError(".logproto.LabelResponse.values: array expected");
+                message.values = [];
+                for (var i = 0; i < object.values.length; ++i)
+                    message.values[i] = String(object.values[i]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a LabelResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.LabelResponse
+         * @static
+         * @param {logproto.LabelResponse} message LabelResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        LabelResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.values = [];
+            if (message.values && message.values.length) {
+                object.values = [];
+                for (var j = 0; j < message.values.length; ++j)
+                    object.values[j] = message.values[j];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this LabelResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.LabelResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        LabelResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return LabelResponse;
+    })();
+
+    logproto.Stream = (function() {
+
+        /**
+         * Properties of a Stream.
+         * @memberof logproto
+         * @interface IStream
+         * @property {string|null} [labels] Stream labels
+         * @property {Array.<logproto.IEntry>|null} [entries] Stream entries
+         */
+
+        /**
+         * Constructs a new Stream.
+         * @memberof logproto
+         * @classdesc Represents a Stream.
+         * @implements IStream
+         * @constructor
+         * @param {logproto.IStream=} [properties] Properties to set
+         */
+        function Stream(properties) {
+            this.entries = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-        for (var i = 0; i < message.labels.length; ++i) {
-          var error = $root.logproto.LabelPair.verify(message.labels[i]);
-          if (error) {
-            return "labels." + error;
-          }
+
+        /**
+         * Stream labels.
+         * @member {string} labels
+         * @memberof logproto.Stream
+         * @instance
+         */
+        Stream.prototype.labels = "";
+
+        /**
+         * Stream entries.
+         * @member {Array.<logproto.IEntry>} entries
+         * @memberof logproto.Stream
+         * @instance
+         */
+        Stream.prototype.entries = $util.emptyArray;
+
+        /**
+         * Creates a new Stream instance using the specified properties.
+         * @function create
+         * @memberof logproto.Stream
+         * @static
+         * @param {logproto.IStream=} [properties] Properties to set
+         * @returns {logproto.Stream} Stream instance
+         */
+        Stream.create = function create(properties) {
+            return new Stream(properties);
+        };
+
+        /**
+         * Encodes the specified Stream message. Does not implicitly {@link logproto.Stream.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.Stream
+         * @static
+         * @param {logproto.IStream} message Stream message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Stream.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.labels);
+            if (message.entries != null && message.entries.length)
+                for (var i = 0; i < message.entries.length; ++i)
+                    $root.logproto.Entry.encode(message.entries[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Stream message, length delimited. Does not implicitly {@link logproto.Stream.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.Stream
+         * @static
+         * @param {logproto.IStream} message Stream message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Stream.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Stream message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.Stream
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.Stream} Stream
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Stream.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.Stream();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.labels = reader.string();
+                    break;
+                case 2:
+                    if (!(message.entries && message.entries.length))
+                        message.entries = [];
+                    message.entries.push($root.logproto.Entry.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Stream message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.Stream
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.Stream} Stream
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Stream.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Stream message.
+         * @function verify
+         * @memberof logproto.Stream
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Stream.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                if (!$util.isString(message.labels))
+                    return "labels: string expected";
+            if (message.entries != null && message.hasOwnProperty("entries")) {
+                if (!Array.isArray(message.entries))
+                    return "entries: array expected";
+                for (var i = 0; i < message.entries.length; ++i) {
+                    var error = $root.logproto.Entry.verify(message.entries[i]);
+                    if (error)
+                        return "entries." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a Stream message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.Stream
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.Stream} Stream
+         */
+        Stream.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.Stream)
+                return object;
+            var message = new $root.logproto.Stream();
+            if (object.labels != null)
+                message.labels = String(object.labels);
+            if (object.entries) {
+                if (!Array.isArray(object.entries))
+                    throw TypeError(".logproto.Stream.entries: array expected");
+                message.entries = [];
+                for (var i = 0; i < object.entries.length; ++i) {
+                    if (typeof object.entries[i] !== "object")
+                        throw TypeError(".logproto.Stream.entries: object expected");
+                    message.entries[i] = $root.logproto.Entry.fromObject(object.entries[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Stream message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.Stream
+         * @static
+         * @param {logproto.Stream} message Stream
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Stream.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.entries = [];
+            if (options.defaults)
+                object.labels = "";
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                object.labels = message.labels;
+            if (message.entries && message.entries.length) {
+                object.entries = [];
+                for (var j = 0; j < message.entries.length; ++j)
+                    object.entries[j] = $root.logproto.Entry.toObject(message.entries[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this Stream to JSON.
+         * @function toJSON
+         * @memberof logproto.Stream
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Stream.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Stream;
+    })();
+
+    logproto.Entry = (function() {
+
+        /**
+         * Properties of an Entry.
+         * @memberof logproto
+         * @interface IEntry
+         * @property {google.protobuf.ITimestamp|null} [timestamp] Entry timestamp
+         * @property {string|null} [line] Entry line
+         */
+
+        /**
+         * Constructs a new Entry.
+         * @memberof logproto
+         * @classdesc Represents an Entry.
+         * @implements IEntry
+         * @constructor
+         * @param {logproto.IEntry=} [properties] Properties to set
+         */
+        function Entry(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      if (message.chunks != null && message.hasOwnProperty("chunks")) {
-        if (!Array.isArray(message.chunks)) {
-          return "chunks: array expected";
+
+        /**
+         * Entry timestamp.
+         * @member {google.protobuf.ITimestamp|null|undefined} timestamp
+         * @memberof logproto.Entry
+         * @instance
+         */
+        Entry.prototype.timestamp = null;
+
+        /**
+         * Entry line.
+         * @member {string} line
+         * @memberof logproto.Entry
+         * @instance
+         */
+        Entry.prototype.line = "";
+
+        /**
+         * Creates a new Entry instance using the specified properties.
+         * @function create
+         * @memberof logproto.Entry
+         * @static
+         * @param {logproto.IEntry=} [properties] Properties to set
+         * @returns {logproto.Entry} Entry instance
+         */
+        Entry.create = function create(properties) {
+            return new Entry(properties);
+        };
+
+        /**
+         * Encodes the specified Entry message. Does not implicitly {@link logproto.Entry.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.Entry
+         * @static
+         * @param {logproto.IEntry} message Entry message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Entry.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                $root.google.protobuf.Timestamp.encode(message.timestamp, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.line != null && message.hasOwnProperty("line"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.line);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Entry message, length delimited. Does not implicitly {@link logproto.Entry.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.Entry
+         * @static
+         * @param {logproto.IEntry} message Entry message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Entry.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an Entry message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.Entry
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.Entry} Entry
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Entry.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.Entry();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.timestamp = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.line = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an Entry message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.Entry
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.Entry} Entry
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Entry.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an Entry message.
+         * @function verify
+         * @memberof logproto.Entry
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Entry.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.timestamp != null && message.hasOwnProperty("timestamp")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.timestamp);
+                if (error)
+                    return "timestamp." + error;
+            }
+            if (message.line != null && message.hasOwnProperty("line"))
+                if (!$util.isString(message.line))
+                    return "line: string expected";
+            return null;
+        };
+
+        /**
+         * Creates an Entry message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.Entry
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.Entry} Entry
+         */
+        Entry.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.Entry)
+                return object;
+            var message = new $root.logproto.Entry();
+            if (object.timestamp != null) {
+                if (typeof object.timestamp !== "object")
+                    throw TypeError(".logproto.Entry.timestamp: object expected");
+                message.timestamp = $root.google.protobuf.Timestamp.fromObject(object.timestamp);
+            }
+            if (object.line != null)
+                message.line = String(object.line);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an Entry message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.Entry
+         * @static
+         * @param {logproto.Entry} message Entry
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Entry.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.timestamp = null;
+                object.line = "";
+            }
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                object.timestamp = $root.google.protobuf.Timestamp.toObject(message.timestamp, options);
+            if (message.line != null && message.hasOwnProperty("line"))
+                object.line = message.line;
+            return object;
+        };
+
+        /**
+         * Converts this Entry to JSON.
+         * @function toJSON
+         * @memberof logproto.Entry
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Entry.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Entry;
+    })();
+
+    logproto.TailRequest = (function() {
+
+        /**
+         * Properties of a TailRequest.
+         * @memberof logproto
+         * @interface ITailRequest
+         * @property {string|null} [query] TailRequest query
+         * @property {number|null} [delayFor] TailRequest delayFor
+         * @property {number|null} [limit] TailRequest limit
+         * @property {google.protobuf.ITimestamp|null} [start] TailRequest start
+         */
+
+        /**
+         * Constructs a new TailRequest.
+         * @memberof logproto
+         * @classdesc Represents a TailRequest.
+         * @implements ITailRequest
+         * @constructor
+         * @param {logproto.ITailRequest=} [properties] Properties to set
+         */
+        function TailRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-        for (var i = 0; i < message.chunks.length; ++i) {
-          var error = $root.logproto.Chunk.verify(message.chunks[i]);
-          if (error) {
-            return "chunks." + error;
-          }
+
+        /**
+         * TailRequest query.
+         * @member {string} query
+         * @memberof logproto.TailRequest
+         * @instance
+         */
+        TailRequest.prototype.query = "";
+
+        /**
+         * TailRequest delayFor.
+         * @member {number} delayFor
+         * @memberof logproto.TailRequest
+         * @instance
+         */
+        TailRequest.prototype.delayFor = 0;
+
+        /**
+         * TailRequest limit.
+         * @member {number} limit
+         * @memberof logproto.TailRequest
+         * @instance
+         */
+        TailRequest.prototype.limit = 0;
+
+        /**
+         * TailRequest start.
+         * @member {google.protobuf.ITimestamp|null|undefined} start
+         * @memberof logproto.TailRequest
+         * @instance
+         */
+        TailRequest.prototype.start = null;
+
+        /**
+         * Creates a new TailRequest instance using the specified properties.
+         * @function create
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {logproto.ITailRequest=} [properties] Properties to set
+         * @returns {logproto.TailRequest} TailRequest instance
+         */
+        TailRequest.create = function create(properties) {
+            return new TailRequest(properties);
+        };
+
+        /**
+         * Encodes the specified TailRequest message. Does not implicitly {@link logproto.TailRequest.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {logproto.ITailRequest} message TailRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.query != null && message.hasOwnProperty("query"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.query);
+            if (message.delayFor != null && message.hasOwnProperty("delayFor"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.delayFor);
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.limit);
+            if (message.start != null && message.hasOwnProperty("start"))
+                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified TailRequest message, length delimited. Does not implicitly {@link logproto.TailRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {logproto.ITailRequest} message TailRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a TailRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.TailRequest} TailRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.query = reader.string();
+                    break;
+                case 3:
+                    message.delayFor = reader.uint32();
+                    break;
+                case 4:
+                    message.limit = reader.uint32();
+                    break;
+                case 5:
+                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a TailRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.TailRequest} TailRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a TailRequest message.
+         * @function verify
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        TailRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.query != null && message.hasOwnProperty("query"))
+                if (!$util.isString(message.query))
+                    return "query: string expected";
+            if (message.delayFor != null && message.hasOwnProperty("delayFor"))
+                if (!$util.isInteger(message.delayFor))
+                    return "delayFor: integer expected";
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                if (!$util.isInteger(message.limit))
+                    return "limit: integer expected";
+            if (message.start != null && message.hasOwnProperty("start")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.start);
+                if (error)
+                    return "start." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a TailRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.TailRequest} TailRequest
+         */
+        TailRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.TailRequest)
+                return object;
+            var message = new $root.logproto.TailRequest();
+            if (object.query != null)
+                message.query = String(object.query);
+            if (object.delayFor != null)
+                message.delayFor = object.delayFor >>> 0;
+            if (object.limit != null)
+                message.limit = object.limit >>> 0;
+            if (object.start != null) {
+                if (typeof object.start !== "object")
+                    throw TypeError(".logproto.TailRequest.start: object expected");
+                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a TailRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.TailRequest
+         * @static
+         * @param {logproto.TailRequest} message TailRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        TailRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.query = "";
+                object.delayFor = 0;
+                object.limit = 0;
+                object.start = null;
+            }
+            if (message.query != null && message.hasOwnProperty("query"))
+                object.query = message.query;
+            if (message.delayFor != null && message.hasOwnProperty("delayFor"))
+                object.delayFor = message.delayFor;
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                object.limit = message.limit;
+            if (message.start != null && message.hasOwnProperty("start"))
+                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
+            return object;
+        };
+
+        /**
+         * Converts this TailRequest to JSON.
+         * @function toJSON
+         * @memberof logproto.TailRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        TailRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return TailRequest;
+    })();
+
+    logproto.TailResponse = (function() {
+
+        /**
+         * Properties of a TailResponse.
+         * @memberof logproto
+         * @interface ITailResponse
+         * @property {logproto.IStream|null} [stream] TailResponse stream
+         * @property {Array.<logproto.IDroppedStream>|null} [droppedStreams] TailResponse droppedStreams
+         */
+
+        /**
+         * Constructs a new TailResponse.
+         * @memberof logproto
+         * @classdesc Represents a TailResponse.
+         * @implements ITailResponse
+         * @constructor
+         * @param {logproto.ITailResponse=} [properties] Properties to set
+         */
+        function TailResponse(properties) {
+            this.droppedStreams = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return null;
-    };
 
-    /**
-     * Creates a TimeSeriesChunk message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
-     */
-    TimeSeriesChunk.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.TimeSeriesChunk) {
-        return object;
-      }
-      var message = new $root.logproto.TimeSeriesChunk();
-      if (object.fromIngesterId != null) {
-        message.fromIngesterId = String(object.fromIngesterId);
-      }
-      if (object.userId != null) {
-        message.userId = String(object.userId);
-      }
-      if (object.labels) {
-        if (!Array.isArray(object.labels)) {
-          throw TypeError(".logproto.TimeSeriesChunk.labels: array expected");
+        /**
+         * TailResponse stream.
+         * @member {logproto.IStream|null|undefined} stream
+         * @memberof logproto.TailResponse
+         * @instance
+         */
+        TailResponse.prototype.stream = null;
+
+        /**
+         * TailResponse droppedStreams.
+         * @member {Array.<logproto.IDroppedStream>} droppedStreams
+         * @memberof logproto.TailResponse
+         * @instance
+         */
+        TailResponse.prototype.droppedStreams = $util.emptyArray;
+
+        /**
+         * Creates a new TailResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {logproto.ITailResponse=} [properties] Properties to set
+         * @returns {logproto.TailResponse} TailResponse instance
+         */
+        TailResponse.create = function create(properties) {
+            return new TailResponse(properties);
+        };
+
+        /**
+         * Encodes the specified TailResponse message. Does not implicitly {@link logproto.TailResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {logproto.ITailResponse} message TailResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                $root.logproto.Stream.encode(message.stream, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.droppedStreams != null && message.droppedStreams.length)
+                for (var i = 0; i < message.droppedStreams.length; ++i)
+                    $root.logproto.DroppedStream.encode(message.droppedStreams[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified TailResponse message, length delimited. Does not implicitly {@link logproto.TailResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {logproto.ITailResponse} message TailResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a TailResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.TailResponse} TailResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.stream = $root.logproto.Stream.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    if (!(message.droppedStreams && message.droppedStreams.length))
+                        message.droppedStreams = [];
+                    message.droppedStreams.push($root.logproto.DroppedStream.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a TailResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.TailResponse} TailResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a TailResponse message.
+         * @function verify
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        TailResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.stream != null && message.hasOwnProperty("stream")) {
+                var error = $root.logproto.Stream.verify(message.stream);
+                if (error)
+                    return "stream." + error;
+            }
+            if (message.droppedStreams != null && message.hasOwnProperty("droppedStreams")) {
+                if (!Array.isArray(message.droppedStreams))
+                    return "droppedStreams: array expected";
+                for (var i = 0; i < message.droppedStreams.length; ++i) {
+                    var error = $root.logproto.DroppedStream.verify(message.droppedStreams[i]);
+                    if (error)
+                        return "droppedStreams." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a TailResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.TailResponse} TailResponse
+         */
+        TailResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.TailResponse)
+                return object;
+            var message = new $root.logproto.TailResponse();
+            if (object.stream != null) {
+                if (typeof object.stream !== "object")
+                    throw TypeError(".logproto.TailResponse.stream: object expected");
+                message.stream = $root.logproto.Stream.fromObject(object.stream);
+            }
+            if (object.droppedStreams) {
+                if (!Array.isArray(object.droppedStreams))
+                    throw TypeError(".logproto.TailResponse.droppedStreams: array expected");
+                message.droppedStreams = [];
+                for (var i = 0; i < object.droppedStreams.length; ++i) {
+                    if (typeof object.droppedStreams[i] !== "object")
+                        throw TypeError(".logproto.TailResponse.droppedStreams: object expected");
+                    message.droppedStreams[i] = $root.logproto.DroppedStream.fromObject(object.droppedStreams[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a TailResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.TailResponse
+         * @static
+         * @param {logproto.TailResponse} message TailResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        TailResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.droppedStreams = [];
+            if (options.defaults)
+                object.stream = null;
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                object.stream = $root.logproto.Stream.toObject(message.stream, options);
+            if (message.droppedStreams && message.droppedStreams.length) {
+                object.droppedStreams = [];
+                for (var j = 0; j < message.droppedStreams.length; ++j)
+                    object.droppedStreams[j] = $root.logproto.DroppedStream.toObject(message.droppedStreams[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this TailResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.TailResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        TailResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return TailResponse;
+    })();
+
+    logproto.SeriesRequest = (function() {
+
+        /**
+         * Properties of a SeriesRequest.
+         * @memberof logproto
+         * @interface ISeriesRequest
+         * @property {google.protobuf.ITimestamp|null} [start] SeriesRequest start
+         * @property {google.protobuf.ITimestamp|null} [end] SeriesRequest end
+         * @property {Array.<string>|null} [groups] SeriesRequest groups
+         */
+
+        /**
+         * Constructs a new SeriesRequest.
+         * @memberof logproto
+         * @classdesc Represents a SeriesRequest.
+         * @implements ISeriesRequest
+         * @constructor
+         * @param {logproto.ISeriesRequest=} [properties] Properties to set
+         */
+        function SeriesRequest(properties) {
+            this.groups = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-        message.labels = [];
-        for (var i = 0; i < object.labels.length; ++i) {
-          if (typeof object.labels[i] !== "object") {
-            throw TypeError(
-              ".logproto.TimeSeriesChunk.labels: object expected"
-            );
-          }
-          message.labels[i] = $root.logproto.LabelPair.fromObject(
-            object.labels[i]
-          );
+
+        /**
+         * SeriesRequest start.
+         * @member {google.protobuf.ITimestamp|null|undefined} start
+         * @memberof logproto.SeriesRequest
+         * @instance
+         */
+        SeriesRequest.prototype.start = null;
+
+        /**
+         * SeriesRequest end.
+         * @member {google.protobuf.ITimestamp|null|undefined} end
+         * @memberof logproto.SeriesRequest
+         * @instance
+         */
+        SeriesRequest.prototype.end = null;
+
+        /**
+         * SeriesRequest groups.
+         * @member {Array.<string>} groups
+         * @memberof logproto.SeriesRequest
+         * @instance
+         */
+        SeriesRequest.prototype.groups = $util.emptyArray;
+
+        /**
+         * Creates a new SeriesRequest instance using the specified properties.
+         * @function create
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {logproto.ISeriesRequest=} [properties] Properties to set
+         * @returns {logproto.SeriesRequest} SeriesRequest instance
+         */
+        SeriesRequest.create = function create(properties) {
+            return new SeriesRequest(properties);
+        };
+
+        /**
+         * Encodes the specified SeriesRequest message. Does not implicitly {@link logproto.SeriesRequest.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {logproto.ISeriesRequest} message SeriesRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        SeriesRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.start != null && message.hasOwnProperty("start"))
+                $root.google.protobuf.Timestamp.encode(message.start, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.end != null && message.hasOwnProperty("end"))
+                $root.google.protobuf.Timestamp.encode(message.end, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.groups != null && message.groups.length)
+                for (var i = 0; i < message.groups.length; ++i)
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.groups[i]);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified SeriesRequest message, length delimited. Does not implicitly {@link logproto.SeriesRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {logproto.ISeriesRequest} message SeriesRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        SeriesRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a SeriesRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.SeriesRequest} SeriesRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        SeriesRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.SeriesRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.start = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.end = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    if (!(message.groups && message.groups.length))
+                        message.groups = [];
+                    message.groups.push(reader.string());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a SeriesRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.SeriesRequest} SeriesRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        SeriesRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a SeriesRequest message.
+         * @function verify
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        SeriesRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.start != null && message.hasOwnProperty("start")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.start);
+                if (error)
+                    return "start." + error;
+            }
+            if (message.end != null && message.hasOwnProperty("end")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.end);
+                if (error)
+                    return "end." + error;
+            }
+            if (message.groups != null && message.hasOwnProperty("groups")) {
+                if (!Array.isArray(message.groups))
+                    return "groups: array expected";
+                for (var i = 0; i < message.groups.length; ++i)
+                    if (!$util.isString(message.groups[i]))
+                        return "groups: string[] expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a SeriesRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.SeriesRequest} SeriesRequest
+         */
+        SeriesRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.SeriesRequest)
+                return object;
+            var message = new $root.logproto.SeriesRequest();
+            if (object.start != null) {
+                if (typeof object.start !== "object")
+                    throw TypeError(".logproto.SeriesRequest.start: object expected");
+                message.start = $root.google.protobuf.Timestamp.fromObject(object.start);
+            }
+            if (object.end != null) {
+                if (typeof object.end !== "object")
+                    throw TypeError(".logproto.SeriesRequest.end: object expected");
+                message.end = $root.google.protobuf.Timestamp.fromObject(object.end);
+            }
+            if (object.groups) {
+                if (!Array.isArray(object.groups))
+                    throw TypeError(".logproto.SeriesRequest.groups: array expected");
+                message.groups = [];
+                for (var i = 0; i < object.groups.length; ++i)
+                    message.groups[i] = String(object.groups[i]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a SeriesRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.SeriesRequest
+         * @static
+         * @param {logproto.SeriesRequest} message SeriesRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        SeriesRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.groups = [];
+            if (options.defaults) {
+                object.start = null;
+                object.end = null;
+            }
+            if (message.start != null && message.hasOwnProperty("start"))
+                object.start = $root.google.protobuf.Timestamp.toObject(message.start, options);
+            if (message.end != null && message.hasOwnProperty("end"))
+                object.end = $root.google.protobuf.Timestamp.toObject(message.end, options);
+            if (message.groups && message.groups.length) {
+                object.groups = [];
+                for (var j = 0; j < message.groups.length; ++j)
+                    object.groups[j] = message.groups[j];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this SeriesRequest to JSON.
+         * @function toJSON
+         * @memberof logproto.SeriesRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        SeriesRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return SeriesRequest;
+    })();
+
+    logproto.SeriesResponse = (function() {
+
+        /**
+         * Properties of a SeriesResponse.
+         * @memberof logproto
+         * @interface ISeriesResponse
+         * @property {Array.<logproto.ISeriesIdentifier>|null} [series] SeriesResponse series
+         */
+
+        /**
+         * Constructs a new SeriesResponse.
+         * @memberof logproto
+         * @classdesc Represents a SeriesResponse.
+         * @implements ISeriesResponse
+         * @constructor
+         * @param {logproto.ISeriesResponse=} [properties] Properties to set
+         */
+        function SeriesResponse(properties) {
+            this.series = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      if (object.chunks) {
-        if (!Array.isArray(object.chunks)) {
-          throw TypeError(".logproto.TimeSeriesChunk.chunks: array expected");
+
+        /**
+         * SeriesResponse series.
+         * @member {Array.<logproto.ISeriesIdentifier>} series
+         * @memberof logproto.SeriesResponse
+         * @instance
+         */
+        SeriesResponse.prototype.series = $util.emptyArray;
+
+        /**
+         * Creates a new SeriesResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {logproto.ISeriesResponse=} [properties] Properties to set
+         * @returns {logproto.SeriesResponse} SeriesResponse instance
+         */
+        SeriesResponse.create = function create(properties) {
+            return new SeriesResponse(properties);
+        };
+
+        /**
+         * Encodes the specified SeriesResponse message. Does not implicitly {@link logproto.SeriesResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {logproto.ISeriesResponse} message SeriesResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        SeriesResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.series != null && message.series.length)
+                for (var i = 0; i < message.series.length; ++i)
+                    $root.logproto.SeriesIdentifier.encode(message.series[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified SeriesResponse message, length delimited. Does not implicitly {@link logproto.SeriesResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {logproto.ISeriesResponse} message SeriesResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        SeriesResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a SeriesResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.SeriesResponse} SeriesResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        SeriesResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.SeriesResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.series && message.series.length))
+                        message.series = [];
+                    message.series.push($root.logproto.SeriesIdentifier.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a SeriesResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.SeriesResponse} SeriesResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        SeriesResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a SeriesResponse message.
+         * @function verify
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        SeriesResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.series != null && message.hasOwnProperty("series")) {
+                if (!Array.isArray(message.series))
+                    return "series: array expected";
+                for (var i = 0; i < message.series.length; ++i) {
+                    var error = $root.logproto.SeriesIdentifier.verify(message.series[i]);
+                    if (error)
+                        return "series." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a SeriesResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.SeriesResponse} SeriesResponse
+         */
+        SeriesResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.SeriesResponse)
+                return object;
+            var message = new $root.logproto.SeriesResponse();
+            if (object.series) {
+                if (!Array.isArray(object.series))
+                    throw TypeError(".logproto.SeriesResponse.series: array expected");
+                message.series = [];
+                for (var i = 0; i < object.series.length; ++i) {
+                    if (typeof object.series[i] !== "object")
+                        throw TypeError(".logproto.SeriesResponse.series: object expected");
+                    message.series[i] = $root.logproto.SeriesIdentifier.fromObject(object.series[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a SeriesResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.SeriesResponse
+         * @static
+         * @param {logproto.SeriesResponse} message SeriesResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        SeriesResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.series = [];
+            if (message.series && message.series.length) {
+                object.series = [];
+                for (var j = 0; j < message.series.length; ++j)
+                    object.series[j] = $root.logproto.SeriesIdentifier.toObject(message.series[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this SeriesResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.SeriesResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        SeriesResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return SeriesResponse;
+    })();
+
+    logproto.SeriesIdentifier = (function() {
+
+        /**
+         * Properties of a SeriesIdentifier.
+         * @memberof logproto
+         * @interface ISeriesIdentifier
+         * @property {Object.<string,string>|null} [labels] SeriesIdentifier labels
+         */
+
+        /**
+         * Constructs a new SeriesIdentifier.
+         * @memberof logproto
+         * @classdesc Represents a SeriesIdentifier.
+         * @implements ISeriesIdentifier
+         * @constructor
+         * @param {logproto.ISeriesIdentifier=} [properties] Properties to set
+         */
+        function SeriesIdentifier(properties) {
+            this.labels = {};
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-        message.chunks = [];
-        for (var i = 0; i < object.chunks.length; ++i) {
-          if (typeof object.chunks[i] !== "object") {
-            throw TypeError(
-              ".logproto.TimeSeriesChunk.chunks: object expected"
-            );
-          }
-          message.chunks[i] = $root.logproto.Chunk.fromObject(object.chunks[i]);
+
+        /**
+         * SeriesIdentifier labels.
+         * @member {Object.<string,string>} labels
+         * @memberof logproto.SeriesIdentifier
+         * @instance
+         */
+        SeriesIdentifier.prototype.labels = $util.emptyObject;
+
+        /**
+         * Creates a new SeriesIdentifier instance using the specified properties.
+         * @function create
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {logproto.ISeriesIdentifier=} [properties] Properties to set
+         * @returns {logproto.SeriesIdentifier} SeriesIdentifier instance
+         */
+        SeriesIdentifier.create = function create(properties) {
+            return new SeriesIdentifier(properties);
+        };
+
+        /**
+         * Encodes the specified SeriesIdentifier message. Does not implicitly {@link logproto.SeriesIdentifier.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {logproto.ISeriesIdentifier} message SeriesIdentifier message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        SeriesIdentifier.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                for (var keys = Object.keys(message.labels), i = 0; i < keys.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.labels[keys[i]]).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified SeriesIdentifier message, length delimited. Does not implicitly {@link logproto.SeriesIdentifier.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {logproto.ISeriesIdentifier} message SeriesIdentifier message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        SeriesIdentifier.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a SeriesIdentifier message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.SeriesIdentifier} SeriesIdentifier
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        SeriesIdentifier.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.SeriesIdentifier(), key;
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    reader.skip().pos++;
+                    if (message.labels === $util.emptyObject)
+                        message.labels = {};
+                    key = reader.string();
+                    reader.pos++;
+                    message.labels[key] = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a SeriesIdentifier message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.SeriesIdentifier} SeriesIdentifier
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        SeriesIdentifier.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a SeriesIdentifier message.
+         * @function verify
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        SeriesIdentifier.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.labels != null && message.hasOwnProperty("labels")) {
+                if (!$util.isObject(message.labels))
+                    return "labels: object expected";
+                var key = Object.keys(message.labels);
+                for (var i = 0; i < key.length; ++i)
+                    if (!$util.isString(message.labels[key[i]]))
+                        return "labels: string{k:string} expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a SeriesIdentifier message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.SeriesIdentifier} SeriesIdentifier
+         */
+        SeriesIdentifier.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.SeriesIdentifier)
+                return object;
+            var message = new $root.logproto.SeriesIdentifier();
+            if (object.labels) {
+                if (typeof object.labels !== "object")
+                    throw TypeError(".logproto.SeriesIdentifier.labels: object expected");
+                message.labels = {};
+                for (var keys = Object.keys(object.labels), i = 0; i < keys.length; ++i)
+                    message.labels[keys[i]] = String(object.labels[keys[i]]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a SeriesIdentifier message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.SeriesIdentifier
+         * @static
+         * @param {logproto.SeriesIdentifier} message SeriesIdentifier
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        SeriesIdentifier.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.objects || options.defaults)
+                object.labels = {};
+            var keys2;
+            if (message.labels && (keys2 = Object.keys(message.labels)).length) {
+                object.labels = {};
+                for (var j = 0; j < keys2.length; ++j)
+                    object.labels[keys2[j]] = message.labels[keys2[j]];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this SeriesIdentifier to JSON.
+         * @function toJSON
+         * @memberof logproto.SeriesIdentifier
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        SeriesIdentifier.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return SeriesIdentifier;
+    })();
+
+    logproto.DroppedStream = (function() {
+
+        /**
+         * Properties of a DroppedStream.
+         * @memberof logproto
+         * @interface IDroppedStream
+         * @property {google.protobuf.ITimestamp|null} [from] DroppedStream from
+         * @property {google.protobuf.ITimestamp|null} [to] DroppedStream to
+         * @property {string|null} [labels] DroppedStream labels
+         */
+
+        /**
+         * Constructs a new DroppedStream.
+         * @memberof logproto
+         * @classdesc Represents a DroppedStream.
+         * @implements IDroppedStream
+         * @constructor
+         * @param {logproto.IDroppedStream=} [properties] Properties to set
+         */
+        function DroppedStream(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return message;
-    };
 
-    /**
-     * Creates a plain object from a TimeSeriesChunk message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.TimeSeriesChunk
-     * @static
-     * @param {logproto.TimeSeriesChunk} message TimeSeriesChunk
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    TimeSeriesChunk.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.arrays || options.defaults) {
-        object.labels = [];
-        object.chunks = [];
-      }
-      if (options.defaults) {
-        object.fromIngesterId = "";
-        object.userId = "";
-      }
-      if (
-        message.fromIngesterId != null &&
-        message.hasOwnProperty("fromIngesterId")
-      ) {
-        object.fromIngesterId = message.fromIngesterId;
-      }
-      if (message.userId != null && message.hasOwnProperty("userId")) {
-        object.userId = message.userId;
-      }
-      if (message.labels && message.labels.length) {
-        object.labels = [];
-        for (var j = 0; j < message.labels.length; ++j) {
-          object.labels[j] = $root.logproto.LabelPair.toObject(
-            message.labels[j],
-            options
-          );
+        /**
+         * DroppedStream from.
+         * @member {google.protobuf.ITimestamp|null|undefined} from
+         * @memberof logproto.DroppedStream
+         * @instance
+         */
+        DroppedStream.prototype.from = null;
+
+        /**
+         * DroppedStream to.
+         * @member {google.protobuf.ITimestamp|null|undefined} to
+         * @memberof logproto.DroppedStream
+         * @instance
+         */
+        DroppedStream.prototype.to = null;
+
+        /**
+         * DroppedStream labels.
+         * @member {string} labels
+         * @memberof logproto.DroppedStream
+         * @instance
+         */
+        DroppedStream.prototype.labels = "";
+
+        /**
+         * Creates a new DroppedStream instance using the specified properties.
+         * @function create
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {logproto.IDroppedStream=} [properties] Properties to set
+         * @returns {logproto.DroppedStream} DroppedStream instance
+         */
+        DroppedStream.create = function create(properties) {
+            return new DroppedStream(properties);
+        };
+
+        /**
+         * Encodes the specified DroppedStream message. Does not implicitly {@link logproto.DroppedStream.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {logproto.IDroppedStream} message DroppedStream message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DroppedStream.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.from != null && message.hasOwnProperty("from"))
+                $root.google.protobuf.Timestamp.encode(message.from, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.to != null && message.hasOwnProperty("to"))
+                $root.google.protobuf.Timestamp.encode(message.to, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.labels);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified DroppedStream message, length delimited. Does not implicitly {@link logproto.DroppedStream.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {logproto.IDroppedStream} message DroppedStream message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DroppedStream.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a DroppedStream message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.DroppedStream} DroppedStream
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DroppedStream.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.DroppedStream();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.from = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.to = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.labels = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a DroppedStream message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.DroppedStream} DroppedStream
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DroppedStream.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a DroppedStream message.
+         * @function verify
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        DroppedStream.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.from != null && message.hasOwnProperty("from")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.from);
+                if (error)
+                    return "from." + error;
+            }
+            if (message.to != null && message.hasOwnProperty("to")) {
+                var error = $root.google.protobuf.Timestamp.verify(message.to);
+                if (error)
+                    return "to." + error;
+            }
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                if (!$util.isString(message.labels))
+                    return "labels: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a DroppedStream message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.DroppedStream} DroppedStream
+         */
+        DroppedStream.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.DroppedStream)
+                return object;
+            var message = new $root.logproto.DroppedStream();
+            if (object.from != null) {
+                if (typeof object.from !== "object")
+                    throw TypeError(".logproto.DroppedStream.from: object expected");
+                message.from = $root.google.protobuf.Timestamp.fromObject(object.from);
+            }
+            if (object.to != null) {
+                if (typeof object.to !== "object")
+                    throw TypeError(".logproto.DroppedStream.to: object expected");
+                message.to = $root.google.protobuf.Timestamp.fromObject(object.to);
+            }
+            if (object.labels != null)
+                message.labels = String(object.labels);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a DroppedStream message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.DroppedStream
+         * @static
+         * @param {logproto.DroppedStream} message DroppedStream
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        DroppedStream.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.from = null;
+                object.to = null;
+                object.labels = "";
+            }
+            if (message.from != null && message.hasOwnProperty("from"))
+                object.from = $root.google.protobuf.Timestamp.toObject(message.from, options);
+            if (message.to != null && message.hasOwnProperty("to"))
+                object.to = $root.google.protobuf.Timestamp.toObject(message.to, options);
+            if (message.labels != null && message.hasOwnProperty("labels"))
+                object.labels = message.labels;
+            return object;
+        };
+
+        /**
+         * Converts this DroppedStream to JSON.
+         * @function toJSON
+         * @memberof logproto.DroppedStream
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        DroppedStream.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return DroppedStream;
+    })();
+
+    logproto.TimeSeriesChunk = (function() {
+
+        /**
+         * Properties of a TimeSeriesChunk.
+         * @memberof logproto
+         * @interface ITimeSeriesChunk
+         * @property {string|null} [fromIngesterId] TimeSeriesChunk fromIngesterId
+         * @property {string|null} [userId] TimeSeriesChunk userId
+         * @property {Array.<logproto.ILabelPair>|null} [labels] TimeSeriesChunk labels
+         * @property {Array.<logproto.IChunk>|null} [chunks] TimeSeriesChunk chunks
+         */
+
+        /**
+         * Constructs a new TimeSeriesChunk.
+         * @memberof logproto
+         * @classdesc Represents a TimeSeriesChunk.
+         * @implements ITimeSeriesChunk
+         * @constructor
+         * @param {logproto.ITimeSeriesChunk=} [properties] Properties to set
+         */
+        function TimeSeriesChunk(properties) {
+            this.labels = [];
+            this.chunks = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      if (message.chunks && message.chunks.length) {
-        object.chunks = [];
-        for (var j = 0; j < message.chunks.length; ++j) {
-          object.chunks[j] = $root.logproto.Chunk.toObject(
-            message.chunks[j],
-            options
-          );
+
+        /**
+         * TimeSeriesChunk fromIngesterId.
+         * @member {string} fromIngesterId
+         * @memberof logproto.TimeSeriesChunk
+         * @instance
+         */
+        TimeSeriesChunk.prototype.fromIngesterId = "";
+
+        /**
+         * TimeSeriesChunk userId.
+         * @member {string} userId
+         * @memberof logproto.TimeSeriesChunk
+         * @instance
+         */
+        TimeSeriesChunk.prototype.userId = "";
+
+        /**
+         * TimeSeriesChunk labels.
+         * @member {Array.<logproto.ILabelPair>} labels
+         * @memberof logproto.TimeSeriesChunk
+         * @instance
+         */
+        TimeSeriesChunk.prototype.labels = $util.emptyArray;
+
+        /**
+         * TimeSeriesChunk chunks.
+         * @member {Array.<logproto.IChunk>} chunks
+         * @memberof logproto.TimeSeriesChunk
+         * @instance
+         */
+        TimeSeriesChunk.prototype.chunks = $util.emptyArray;
+
+        /**
+         * Creates a new TimeSeriesChunk instance using the specified properties.
+         * @function create
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {logproto.ITimeSeriesChunk=} [properties] Properties to set
+         * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk instance
+         */
+        TimeSeriesChunk.create = function create(properties) {
+            return new TimeSeriesChunk(properties);
+        };
+
+        /**
+         * Encodes the specified TimeSeriesChunk message. Does not implicitly {@link logproto.TimeSeriesChunk.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {logproto.ITimeSeriesChunk} message TimeSeriesChunk message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TimeSeriesChunk.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.fromIngesterId != null && message.hasOwnProperty("fromIngesterId"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.fromIngesterId);
+            if (message.userId != null && message.hasOwnProperty("userId"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.userId);
+            if (message.labels != null && message.labels.length)
+                for (var i = 0; i < message.labels.length; ++i)
+                    $root.logproto.LabelPair.encode(message.labels[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.chunks != null && message.chunks.length)
+                for (var i = 0; i < message.chunks.length; ++i)
+                    $root.logproto.Chunk.encode(message.chunks[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified TimeSeriesChunk message, length delimited. Does not implicitly {@link logproto.TimeSeriesChunk.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {logproto.ITimeSeriesChunk} message TimeSeriesChunk message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TimeSeriesChunk.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a TimeSeriesChunk message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TimeSeriesChunk.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TimeSeriesChunk();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.fromIngesterId = reader.string();
+                    break;
+                case 2:
+                    message.userId = reader.string();
+                    break;
+                case 3:
+                    if (!(message.labels && message.labels.length))
+                        message.labels = [];
+                    message.labels.push($root.logproto.LabelPair.decode(reader, reader.uint32()));
+                    break;
+                case 4:
+                    if (!(message.chunks && message.chunks.length))
+                        message.chunks = [];
+                    message.chunks.push($root.logproto.Chunk.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a TimeSeriesChunk message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TimeSeriesChunk.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a TimeSeriesChunk message.
+         * @function verify
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        TimeSeriesChunk.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.fromIngesterId != null && message.hasOwnProperty("fromIngesterId"))
+                if (!$util.isString(message.fromIngesterId))
+                    return "fromIngesterId: string expected";
+            if (message.userId != null && message.hasOwnProperty("userId"))
+                if (!$util.isString(message.userId))
+                    return "userId: string expected";
+            if (message.labels != null && message.hasOwnProperty("labels")) {
+                if (!Array.isArray(message.labels))
+                    return "labels: array expected";
+                for (var i = 0; i < message.labels.length; ++i) {
+                    var error = $root.logproto.LabelPair.verify(message.labels[i]);
+                    if (error)
+                        return "labels." + error;
+                }
+            }
+            if (message.chunks != null && message.hasOwnProperty("chunks")) {
+                if (!Array.isArray(message.chunks))
+                    return "chunks: array expected";
+                for (var i = 0; i < message.chunks.length; ++i) {
+                    var error = $root.logproto.Chunk.verify(message.chunks[i]);
+                    if (error)
+                        return "chunks." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a TimeSeriesChunk message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.TimeSeriesChunk} TimeSeriesChunk
+         */
+        TimeSeriesChunk.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.TimeSeriesChunk)
+                return object;
+            var message = new $root.logproto.TimeSeriesChunk();
+            if (object.fromIngesterId != null)
+                message.fromIngesterId = String(object.fromIngesterId);
+            if (object.userId != null)
+                message.userId = String(object.userId);
+            if (object.labels) {
+                if (!Array.isArray(object.labels))
+                    throw TypeError(".logproto.TimeSeriesChunk.labels: array expected");
+                message.labels = [];
+                for (var i = 0; i < object.labels.length; ++i) {
+                    if (typeof object.labels[i] !== "object")
+                        throw TypeError(".logproto.TimeSeriesChunk.labels: object expected");
+                    message.labels[i] = $root.logproto.LabelPair.fromObject(object.labels[i]);
+                }
+            }
+            if (object.chunks) {
+                if (!Array.isArray(object.chunks))
+                    throw TypeError(".logproto.TimeSeriesChunk.chunks: array expected");
+                message.chunks = [];
+                for (var i = 0; i < object.chunks.length; ++i) {
+                    if (typeof object.chunks[i] !== "object")
+                        throw TypeError(".logproto.TimeSeriesChunk.chunks: object expected");
+                    message.chunks[i] = $root.logproto.Chunk.fromObject(object.chunks[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a TimeSeriesChunk message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.TimeSeriesChunk
+         * @static
+         * @param {logproto.TimeSeriesChunk} message TimeSeriesChunk
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        TimeSeriesChunk.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults) {
+                object.labels = [];
+                object.chunks = [];
+            }
+            if (options.defaults) {
+                object.fromIngesterId = "";
+                object.userId = "";
+            }
+            if (message.fromIngesterId != null && message.hasOwnProperty("fromIngesterId"))
+                object.fromIngesterId = message.fromIngesterId;
+            if (message.userId != null && message.hasOwnProperty("userId"))
+                object.userId = message.userId;
+            if (message.labels && message.labels.length) {
+                object.labels = [];
+                for (var j = 0; j < message.labels.length; ++j)
+                    object.labels[j] = $root.logproto.LabelPair.toObject(message.labels[j], options);
+            }
+            if (message.chunks && message.chunks.length) {
+                object.chunks = [];
+                for (var j = 0; j < message.chunks.length; ++j)
+                    object.chunks[j] = $root.logproto.Chunk.toObject(message.chunks[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this TimeSeriesChunk to JSON.
+         * @function toJSON
+         * @memberof logproto.TimeSeriesChunk
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        TimeSeriesChunk.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return TimeSeriesChunk;
+    })();
+
+    logproto.LabelPair = (function() {
+
+        /**
+         * Properties of a LabelPair.
+         * @memberof logproto
+         * @interface ILabelPair
+         * @property {string|null} [name] LabelPair name
+         * @property {string|null} [value] LabelPair value
+         */
+
+        /**
+         * Constructs a new LabelPair.
+         * @memberof logproto
+         * @classdesc Represents a LabelPair.
+         * @implements ILabelPair
+         * @constructor
+         * @param {logproto.ILabelPair=} [properties] Properties to set
+         */
+        function LabelPair(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return object;
-    };
 
-    /**
-     * Converts this TimeSeriesChunk to JSON.
-     * @function toJSON
-     * @memberof logproto.TimeSeriesChunk
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    TimeSeriesChunk.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
+        /**
+         * LabelPair name.
+         * @member {string} name
+         * @memberof logproto.LabelPair
+         * @instance
+         */
+        LabelPair.prototype.name = "";
 
-    return TimeSeriesChunk;
-  })();
+        /**
+         * LabelPair value.
+         * @member {string} value
+         * @memberof logproto.LabelPair
+         * @instance
+         */
+        LabelPair.prototype.value = "";
 
-  logproto.LabelPair = (function() {
-    /**
-     * Properties of a LabelPair.
-     * @memberof logproto
-     * @interface ILabelPair
-     * @property {string|null} [name] LabelPair name
-     * @property {string|null} [value] LabelPair value
-     */
+        /**
+         * Creates a new LabelPair instance using the specified properties.
+         * @function create
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {logproto.ILabelPair=} [properties] Properties to set
+         * @returns {logproto.LabelPair} LabelPair instance
+         */
+        LabelPair.create = function create(properties) {
+            return new LabelPair(properties);
+        };
 
-    /**
-     * Constructs a new LabelPair.
-     * @memberof logproto
-     * @classdesc Represents a LabelPair.
-     * @implements ILabelPair
-     * @constructor
-     * @param {logproto.ILabelPair=} [properties] Properties to set
-     */
-    function LabelPair(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
+        /**
+         * Encodes the specified LabelPair message. Does not implicitly {@link logproto.LabelPair.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {logproto.ILabelPair} message LabelPair message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        LabelPair.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.name != null && message.hasOwnProperty("name"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+            if (message.value != null && message.hasOwnProperty("value"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.value);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified LabelPair message, length delimited. Does not implicitly {@link logproto.LabelPair.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {logproto.ILabelPair} message LabelPair message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        LabelPair.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a LabelPair message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.LabelPair} LabelPair
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        LabelPair.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.LabelPair();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.name = reader.string();
+                    break;
+                case 2:
+                    message.value = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a LabelPair message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.LabelPair} LabelPair
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        LabelPair.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a LabelPair message.
+         * @function verify
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        LabelPair.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.name != null && message.hasOwnProperty("name"))
+                if (!$util.isString(message.name))
+                    return "name: string expected";
+            if (message.value != null && message.hasOwnProperty("value"))
+                if (!$util.isString(message.value))
+                    return "value: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a LabelPair message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.LabelPair} LabelPair
+         */
+        LabelPair.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.LabelPair)
+                return object;
+            var message = new $root.logproto.LabelPair();
+            if (object.name != null)
+                message.name = String(object.name);
+            if (object.value != null)
+                message.value = String(object.value);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a LabelPair message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.LabelPair
+         * @static
+         * @param {logproto.LabelPair} message LabelPair
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        LabelPair.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.name = "";
+                object.value = "";
+            }
+            if (message.name != null && message.hasOwnProperty("name"))
+                object.name = message.name;
+            if (message.value != null && message.hasOwnProperty("value"))
+                object.value = message.value;
+            return object;
+        };
+
+        /**
+         * Converts this LabelPair to JSON.
+         * @function toJSON
+         * @memberof logproto.LabelPair
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        LabelPair.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return LabelPair;
+    })();
+
+    logproto.Chunk = (function() {
+
+        /**
+         * Properties of a Chunk.
+         * @memberof logproto
+         * @interface IChunk
+         * @property {Uint8Array|null} [data] Chunk data
+         */
+
+        /**
+         * Constructs a new Chunk.
+         * @memberof logproto
+         * @classdesc Represents a Chunk.
+         * @implements IChunk
+         * @constructor
+         * @param {logproto.IChunk=} [properties] Properties to set
+         */
+        function Chunk(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-    }
 
-    /**
-     * LabelPair name.
-     * @member {string} name
-     * @memberof logproto.LabelPair
-     * @instance
-     */
-    LabelPair.prototype.name = "";
+        /**
+         * Chunk data.
+         * @member {Uint8Array} data
+         * @memberof logproto.Chunk
+         * @instance
+         */
+        Chunk.prototype.data = $util.newBuffer([]);
 
-    /**
-     * LabelPair value.
-     * @member {string} value
-     * @memberof logproto.LabelPair
-     * @instance
-     */
-    LabelPair.prototype.value = "";
+        /**
+         * Creates a new Chunk instance using the specified properties.
+         * @function create
+         * @memberof logproto.Chunk
+         * @static
+         * @param {logproto.IChunk=} [properties] Properties to set
+         * @returns {logproto.Chunk} Chunk instance
+         */
+        Chunk.create = function create(properties) {
+            return new Chunk(properties);
+        };
 
-    /**
-     * Creates a new LabelPair instance using the specified properties.
-     * @function create
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {logproto.ILabelPair=} [properties] Properties to set
-     * @returns {logproto.LabelPair} LabelPair instance
-     */
-    LabelPair.create = function create(properties) {
-      return new LabelPair(properties);
-    };
+        /**
+         * Encodes the specified Chunk message. Does not implicitly {@link logproto.Chunk.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.Chunk
+         * @static
+         * @param {logproto.IChunk} message Chunk message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Chunk.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.data != null && message.hasOwnProperty("data"))
+                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.data);
+            return writer;
+        };
 
-    /**
-     * Encodes the specified LabelPair message. Does not implicitly {@link logproto.LabelPair.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {logproto.ILabelPair} message LabelPair message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    LabelPair.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.name != null && message.hasOwnProperty("name")) {
-        writer.uint32(/* id 1, wireType 2 = */ 10).string(message.name);
-      }
-      if (message.value != null && message.hasOwnProperty("value")) {
-        writer.uint32(/* id 2, wireType 2 = */ 18).string(message.value);
-      }
-      return writer;
-    };
+        /**
+         * Encodes the specified Chunk message, length delimited. Does not implicitly {@link logproto.Chunk.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.Chunk
+         * @static
+         * @param {logproto.IChunk} message Chunk message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Chunk.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-    /**
-     * Encodes the specified LabelPair message, length delimited. Does not implicitly {@link logproto.LabelPair.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {logproto.ILabelPair} message LabelPair message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    LabelPair.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
+        /**
+         * Decodes a Chunk message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.Chunk
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.Chunk} Chunk
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Chunk.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.Chunk();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.data = reader.bytes();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-    /**
-     * Decodes a LabelPair message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.LabelPair} LabelPair
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    LabelPair.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.LabelPair();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.name = reader.string();
-            break;
-          case 2:
-            message.value = reader.string();
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
+        /**
+         * Decodes a Chunk message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.Chunk
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.Chunk} Chunk
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Chunk.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Chunk message.
+         * @function verify
+         * @memberof logproto.Chunk
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Chunk.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.data != null && message.hasOwnProperty("data"))
+                if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
+                    return "data: buffer expected";
+            return null;
+        };
+
+        /**
+         * Creates a Chunk message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.Chunk
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.Chunk} Chunk
+         */
+        Chunk.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.Chunk)
+                return object;
+            var message = new $root.logproto.Chunk();
+            if (object.data != null)
+                if (typeof object.data === "string")
+                    $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
+                else if (object.data.length)
+                    message.data = object.data;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Chunk message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.Chunk
+         * @static
+         * @param {logproto.Chunk} message Chunk
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Chunk.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults)
+                if (options.bytes === String)
+                    object.data = "";
+                else {
+                    object.data = [];
+                    if (options.bytes !== Array)
+                        object.data = $util.newBuffer(object.data);
+                }
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
+            return object;
+        };
+
+        /**
+         * Converts this Chunk to JSON.
+         * @function toJSON
+         * @memberof logproto.Chunk
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Chunk.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Chunk;
+    })();
+
+    logproto.TransferChunksResponse = (function() {
+
+        /**
+         * Properties of a TransferChunksResponse.
+         * @memberof logproto
+         * @interface ITransferChunksResponse
+         */
+
+        /**
+         * Constructs a new TransferChunksResponse.
+         * @memberof logproto
+         * @classdesc Represents a TransferChunksResponse.
+         * @implements ITransferChunksResponse
+         * @constructor
+         * @param {logproto.ITransferChunksResponse=} [properties] Properties to set
+         */
+        function TransferChunksResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return message;
-    };
 
-    /**
-     * Decodes a LabelPair message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.LabelPair} LabelPair
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    LabelPair.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
+        /**
+         * Creates a new TransferChunksResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {logproto.ITransferChunksResponse=} [properties] Properties to set
+         * @returns {logproto.TransferChunksResponse} TransferChunksResponse instance
+         */
+        TransferChunksResponse.create = function create(properties) {
+            return new TransferChunksResponse(properties);
+        };
 
-    /**
-     * Verifies a LabelPair message.
-     * @function verify
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    LabelPair.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.name != null && message.hasOwnProperty("name")) {
-        if (!$util.isString(message.name)) {
-          return "name: string expected";
+        /**
+         * Encodes the specified TransferChunksResponse message. Does not implicitly {@link logproto.TransferChunksResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {logproto.ITransferChunksResponse} message TransferChunksResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TransferChunksResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified TransferChunksResponse message, length delimited. Does not implicitly {@link logproto.TransferChunksResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {logproto.ITransferChunksResponse} message TransferChunksResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TransferChunksResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a TransferChunksResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.TransferChunksResponse} TransferChunksResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TransferChunksResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TransferChunksResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a TransferChunksResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.TransferChunksResponse} TransferChunksResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TransferChunksResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a TransferChunksResponse message.
+         * @function verify
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        TransferChunksResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            return null;
+        };
+
+        /**
+         * Creates a TransferChunksResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.TransferChunksResponse} TransferChunksResponse
+         */
+        TransferChunksResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.TransferChunksResponse)
+                return object;
+            return new $root.logproto.TransferChunksResponse();
+        };
+
+        /**
+         * Creates a plain object from a TransferChunksResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.TransferChunksResponse
+         * @static
+         * @param {logproto.TransferChunksResponse} message TransferChunksResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        TransferChunksResponse.toObject = function toObject() {
+            return {};
+        };
+
+        /**
+         * Converts this TransferChunksResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.TransferChunksResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        TransferChunksResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return TransferChunksResponse;
+    })();
+
+    logproto.TailersCountRequest = (function() {
+
+        /**
+         * Properties of a TailersCountRequest.
+         * @memberof logproto
+         * @interface ITailersCountRequest
+         */
+
+        /**
+         * Constructs a new TailersCountRequest.
+         * @memberof logproto
+         * @classdesc Represents a TailersCountRequest.
+         * @implements ITailersCountRequest
+         * @constructor
+         * @param {logproto.ITailersCountRequest=} [properties] Properties to set
+         */
+        function TailersCountRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      if (message.value != null && message.hasOwnProperty("value")) {
-        if (!$util.isString(message.value)) {
-          return "value: string expected";
+
+        /**
+         * Creates a new TailersCountRequest instance using the specified properties.
+         * @function create
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {logproto.ITailersCountRequest=} [properties] Properties to set
+         * @returns {logproto.TailersCountRequest} TailersCountRequest instance
+         */
+        TailersCountRequest.create = function create(properties) {
+            return new TailersCountRequest(properties);
+        };
+
+        /**
+         * Encodes the specified TailersCountRequest message. Does not implicitly {@link logproto.TailersCountRequest.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {logproto.ITailersCountRequest} message TailersCountRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailersCountRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified TailersCountRequest message, length delimited. Does not implicitly {@link logproto.TailersCountRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {logproto.ITailersCountRequest} message TailersCountRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailersCountRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a TailersCountRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.TailersCountRequest} TailersCountRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailersCountRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailersCountRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a TailersCountRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.TailersCountRequest} TailersCountRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailersCountRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a TailersCountRequest message.
+         * @function verify
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        TailersCountRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            return null;
+        };
+
+        /**
+         * Creates a TailersCountRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.TailersCountRequest} TailersCountRequest
+         */
+        TailersCountRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.TailersCountRequest)
+                return object;
+            return new $root.logproto.TailersCountRequest();
+        };
+
+        /**
+         * Creates a plain object from a TailersCountRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.TailersCountRequest
+         * @static
+         * @param {logproto.TailersCountRequest} message TailersCountRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        TailersCountRequest.toObject = function toObject() {
+            return {};
+        };
+
+        /**
+         * Converts this TailersCountRequest to JSON.
+         * @function toJSON
+         * @memberof logproto.TailersCountRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        TailersCountRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return TailersCountRequest;
+    })();
+
+    logproto.TailersCountResponse = (function() {
+
+        /**
+         * Properties of a TailersCountResponse.
+         * @memberof logproto
+         * @interface ITailersCountResponse
+         * @property {number|null} [count] TailersCountResponse count
+         */
+
+        /**
+         * Constructs a new TailersCountResponse.
+         * @memberof logproto
+         * @classdesc Represents a TailersCountResponse.
+         * @implements ITailersCountResponse
+         * @constructor
+         * @param {logproto.ITailersCountResponse=} [properties] Properties to set
+         */
+        function TailersCountResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
         }
-      }
-      return null;
-    };
 
-    /**
-     * Creates a LabelPair message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.LabelPair} LabelPair
-     */
-    LabelPair.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.LabelPair) {
-        return object;
-      }
-      var message = new $root.logproto.LabelPair();
-      if (object.name != null) {
-        message.name = String(object.name);
-      }
-      if (object.value != null) {
-        message.value = String(object.value);
-      }
-      return message;
-    };
+        /**
+         * TailersCountResponse count.
+         * @member {number} count
+         * @memberof logproto.TailersCountResponse
+         * @instance
+         */
+        TailersCountResponse.prototype.count = 0;
 
-    /**
-     * Creates a plain object from a LabelPair message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.LabelPair
-     * @static
-     * @param {logproto.LabelPair} message LabelPair
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    LabelPair.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        object.name = "";
-        object.value = "";
-      }
-      if (message.name != null && message.hasOwnProperty("name")) {
-        object.name = message.name;
-      }
-      if (message.value != null && message.hasOwnProperty("value")) {
-        object.value = message.value;
-      }
-      return object;
-    };
+        /**
+         * Creates a new TailersCountResponse instance using the specified properties.
+         * @function create
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {logproto.ITailersCountResponse=} [properties] Properties to set
+         * @returns {logproto.TailersCountResponse} TailersCountResponse instance
+         */
+        TailersCountResponse.create = function create(properties) {
+            return new TailersCountResponse(properties);
+        };
 
-    /**
-     * Converts this LabelPair to JSON.
-     * @function toJSON
-     * @memberof logproto.LabelPair
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    LabelPair.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
+        /**
+         * Encodes the specified TailersCountResponse message. Does not implicitly {@link logproto.TailersCountResponse.verify|verify} messages.
+         * @function encode
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {logproto.ITailersCountResponse} message TailersCountResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailersCountResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.count != null && message.hasOwnProperty("count"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.count);
+            return writer;
+        };
 
-    return LabelPair;
-  })();
+        /**
+         * Encodes the specified TailersCountResponse message, length delimited. Does not implicitly {@link logproto.TailersCountResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {logproto.ITailersCountResponse} message TailersCountResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        TailersCountResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-  logproto.Chunk = (function() {
-    /**
-     * Properties of a Chunk.
-     * @memberof logproto
-     * @interface IChunk
-     * @property {Uint8Array|null} [data] Chunk data
-     */
+        /**
+         * Decodes a TailersCountResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {logproto.TailersCountResponse} TailersCountResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailersCountResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.logproto.TailersCountResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.count = reader.uint32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-    /**
-     * Constructs a new Chunk.
-     * @memberof logproto
-     * @classdesc Represents a Chunk.
-     * @implements IChunk
-     * @constructor
-     * @param {logproto.IChunk=} [properties] Properties to set
-     */
-    function Chunk(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
+        /**
+         * Decodes a TailersCountResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {logproto.TailersCountResponse} TailersCountResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        TailersCountResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-    /**
-     * Chunk data.
-     * @member {Uint8Array} data
-     * @memberof logproto.Chunk
-     * @instance
-     */
-    Chunk.prototype.data = $util.newBuffer([]);
+        /**
+         * Verifies a TailersCountResponse message.
+         * @function verify
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        TailersCountResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.count != null && message.hasOwnProperty("count"))
+                if (!$util.isInteger(message.count))
+                    return "count: integer expected";
+            return null;
+        };
 
-    /**
-     * Creates a new Chunk instance using the specified properties.
-     * @function create
-     * @memberof logproto.Chunk
-     * @static
-     * @param {logproto.IChunk=} [properties] Properties to set
-     * @returns {logproto.Chunk} Chunk instance
-     */
-    Chunk.create = function create(properties) {
-      return new Chunk(properties);
-    };
+        /**
+         * Creates a TailersCountResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {logproto.TailersCountResponse} TailersCountResponse
+         */
+        TailersCountResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.logproto.TailersCountResponse)
+                return object;
+            var message = new $root.logproto.TailersCountResponse();
+            if (object.count != null)
+                message.count = object.count >>> 0;
+            return message;
+        };
 
-    /**
-     * Encodes the specified Chunk message. Does not implicitly {@link logproto.Chunk.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.Chunk
-     * @static
-     * @param {logproto.IChunk} message Chunk message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    Chunk.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      if (message.data != null && message.hasOwnProperty("data")) {
-        writer.uint32(/* id 1, wireType 2 = */ 10).bytes(message.data);
-      }
-      return writer;
-    };
+        /**
+         * Creates a plain object from a TailersCountResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof logproto.TailersCountResponse
+         * @static
+         * @param {logproto.TailersCountResponse} message TailersCountResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        TailersCountResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults)
+                object.count = 0;
+            if (message.count != null && message.hasOwnProperty("count"))
+                object.count = message.count;
+            return object;
+        };
 
-    /**
-     * Encodes the specified Chunk message, length delimited. Does not implicitly {@link logproto.Chunk.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.Chunk
-     * @static
-     * @param {logproto.IChunk} message Chunk message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    Chunk.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
-    };
+        /**
+         * Converts this TailersCountResponse to JSON.
+         * @function toJSON
+         * @memberof logproto.TailersCountResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        TailersCountResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-    /**
-     * Decodes a Chunk message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.Chunk
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.Chunk} Chunk
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    Chunk.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.Chunk();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1:
-            message.data = reader.bytes();
-            break;
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
+        return TailersCountResponse;
+    })();
 
-    /**
-     * Decodes a Chunk message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.Chunk
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.Chunk} Chunk
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    Chunk.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a Chunk message.
-     * @function verify
-     * @memberof logproto.Chunk
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    Chunk.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      if (message.data != null && message.hasOwnProperty("data")) {
-        if (
-          !(
-            (message.data && typeof message.data.length === "number") ||
-            $util.isString(message.data)
-          )
-        ) {
-          return "data: buffer expected";
-        }
-      }
-      return null;
-    };
-
-    /**
-     * Creates a Chunk message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.Chunk
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.Chunk} Chunk
-     */
-    Chunk.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.Chunk) {
-        return object;
-      }
-      var message = new $root.logproto.Chunk();
-      if (object.data != null) {
-        if (typeof object.data === "string") {
-          $util.base64.decode(
-            object.data,
-            (message.data = $util.newBuffer($util.base64.length(object.data))),
-            0
-          );
-        } else if (object.data.length) {
-          message.data = object.data;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Creates a plain object from a Chunk message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.Chunk
-     * @static
-     * @param {logproto.Chunk} message Chunk
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    Chunk.toObject = function toObject(message, options) {
-      if (!options) {
-        options = {};
-      }
-      var object = {};
-      if (options.defaults) {
-        if (options.bytes === String) {
-          object.data = "";
-        } else {
-          object.data = [];
-          if (options.bytes !== Array) {
-            object.data = $util.newBuffer(object.data);
-          }
-        }
-      }
-      if (message.data != null && message.hasOwnProperty("data")) {
-        object.data =
-          options.bytes === String
-            ? $util.base64.encode(message.data, 0, message.data.length)
-            : options.bytes === Array
-            ? Array.prototype.slice.call(message.data)
-            : message.data;
-      }
-      return object;
-    };
-
-    /**
-     * Converts this Chunk to JSON.
-     * @function toJSON
-     * @memberof logproto.Chunk
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    Chunk.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return Chunk;
-  })();
-
-  logproto.TransferChunksResponse = (function() {
-    /**
-     * Properties of a TransferChunksResponse.
-     * @memberof logproto
-     * @interface ITransferChunksResponse
-     */
-
-    /**
-     * Constructs a new TransferChunksResponse.
-     * @memberof logproto
-     * @classdesc Represents a TransferChunksResponse.
-     * @implements ITransferChunksResponse
-     * @constructor
-     * @param {logproto.ITransferChunksResponse=} [properties] Properties to set
-     */
-    function TransferChunksResponse(properties) {
-      if (properties) {
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
-          if (properties[keys[i]] != null) {
-            this[keys[i]] = properties[keys[i]];
-          }
-        }
-      }
-    }
-
-    /**
-     * Creates a new TransferChunksResponse instance using the specified properties.
-     * @function create
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {logproto.ITransferChunksResponse=} [properties] Properties to set
-     * @returns {logproto.TransferChunksResponse} TransferChunksResponse instance
-     */
-    TransferChunksResponse.create = function create(properties) {
-      return new TransferChunksResponse(properties);
-    };
-
-    /**
-     * Encodes the specified TransferChunksResponse message. Does not implicitly {@link logproto.TransferChunksResponse.verify|verify} messages.
-     * @function encode
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {logproto.ITransferChunksResponse} message TransferChunksResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TransferChunksResponse.encode = function encode(message, writer) {
-      if (!writer) {
-        writer = $Writer.create();
-      }
-      return writer;
-    };
-
-    /**
-     * Encodes the specified TransferChunksResponse message, length delimited. Does not implicitly {@link logproto.TransferChunksResponse.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {logproto.ITransferChunksResponse} message TransferChunksResponse message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    TransferChunksResponse.encodeDelimited = function encodeDelimited(
-      message,
-      writer
-    ) {
-      return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a TransferChunksResponse message from the specified reader or buffer.
-     * @function decode
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {logproto.TransferChunksResponse} TransferChunksResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TransferChunksResponse.decode = function decode(reader, length) {
-      if (!(reader instanceof $Reader)) {
-        reader = $Reader.create(reader);
-      }
-      var end = length === undefined ? reader.len : reader.pos + length;
-      var message = new $root.logproto.TransferChunksResponse();
-      while (reader.pos < end) {
-        var tag = reader.uint32();
-        switch (tag >>> 3) {
-          default:
-            reader.skipType(tag & 7);
-            break;
-        }
-      }
-      return message;
-    };
-
-    /**
-     * Decodes a TransferChunksResponse message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {logproto.TransferChunksResponse} TransferChunksResponse
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    TransferChunksResponse.decodeDelimited = function decodeDelimited(reader) {
-      if (!(reader instanceof $Reader)) {
-        reader = new $Reader(reader);
-      }
-      return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a TransferChunksResponse message.
-     * @function verify
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    TransferChunksResponse.verify = function verify(message) {
-      if (typeof message !== "object" || message === null) {
-        return "object expected";
-      }
-      return null;
-    };
-
-    /**
-     * Creates a TransferChunksResponse message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {logproto.TransferChunksResponse} TransferChunksResponse
-     */
-    TransferChunksResponse.fromObject = function fromObject(object) {
-      if (object instanceof $root.logproto.TransferChunksResponse) {
-        return object;
-      }
-      return new $root.logproto.TransferChunksResponse();
-    };
-
-    /**
-     * Creates a plain object from a TransferChunksResponse message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof logproto.TransferChunksResponse
-     * @static
-     * @param {logproto.TransferChunksResponse} message TransferChunksResponse
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    TransferChunksResponse.toObject = function toObject() {
-      return {};
-    };
-
-    /**
-     * Converts this TransferChunksResponse to JSON.
-     * @function toJSON
-     * @memberof logproto.TransferChunksResponse
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    TransferChunksResponse.prototype.toJSON = function toJSON() {
-      return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    return TransferChunksResponse;
-  })();
-
-  return logproto;
+    return logproto;
 })();
 
 $root.google = (function() {
-  /**
-   * Namespace google.
-   * @exports google
-   * @namespace
-   */
-  var google = {};
 
-  google.protobuf = (function() {
     /**
-     * Namespace protobuf.
-     * @memberof google
+     * Namespace google.
+     * @exports google
      * @namespace
      */
-    var protobuf = {};
+    var google = {};
 
-    protobuf.Timestamp = (function() {
-      /**
-       * Properties of a Timestamp.
-       * @memberof google.protobuf
-       * @interface ITimestamp
-       * @property {number|Long|null} [seconds] Timestamp seconds
-       * @property {number|null} [nanos] Timestamp nanos
-       */
+    google.protobuf = (function() {
 
-      /**
-       * Constructs a new Timestamp.
-       * @memberof google.protobuf
-       * @classdesc Represents a Timestamp.
-       * @implements ITimestamp
-       * @constructor
-       * @param {google.protobuf.ITimestamp=} [properties] Properties to set
-       */
-      function Timestamp(properties) {
-        if (properties) {
-          for (
-            var keys = Object.keys(properties), i = 0;
-            i < keys.length;
-            ++i
-          ) {
-            if (properties[keys[i]] != null) {
-              this[keys[i]] = properties[keys[i]];
+        /**
+         * Namespace protobuf.
+         * @memberof google
+         * @namespace
+         */
+        var protobuf = {};
+
+        protobuf.Timestamp = (function() {
+
+            /**
+             * Properties of a Timestamp.
+             * @memberof google.protobuf
+             * @interface ITimestamp
+             * @property {number|Long|null} [seconds] Timestamp seconds
+             * @property {number|null} [nanos] Timestamp nanos
+             */
+
+            /**
+             * Constructs a new Timestamp.
+             * @memberof google.protobuf
+             * @classdesc Represents a Timestamp.
+             * @implements ITimestamp
+             * @constructor
+             * @param {google.protobuf.ITimestamp=} [properties] Properties to set
+             */
+            function Timestamp(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
             }
-          }
-        }
-      }
 
-      /**
-       * Timestamp seconds.
-       * @member {number|Long} seconds
-       * @memberof google.protobuf.Timestamp
-       * @instance
-       */
-      Timestamp.prototype.seconds = $util.Long
-        ? $util.Long.fromBits(0, 0, false)
-        : 0;
+            /**
+             * Timestamp seconds.
+             * @member {number|Long} seconds
+             * @memberof google.protobuf.Timestamp
+             * @instance
+             */
+            Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-      /**
-       * Timestamp nanos.
-       * @member {number} nanos
-       * @memberof google.protobuf.Timestamp
-       * @instance
-       */
-      Timestamp.prototype.nanos = 0;
+            /**
+             * Timestamp nanos.
+             * @member {number} nanos
+             * @memberof google.protobuf.Timestamp
+             * @instance
+             */
+            Timestamp.prototype.nanos = 0;
 
-      /**
-       * Creates a new Timestamp instance using the specified properties.
-       * @function create
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {google.protobuf.ITimestamp=} [properties] Properties to set
-       * @returns {google.protobuf.Timestamp} Timestamp instance
-       */
-      Timestamp.create = function create(properties) {
-        return new Timestamp(properties);
-      };
+            /**
+             * Creates a new Timestamp instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.ITimestamp=} [properties] Properties to set
+             * @returns {google.protobuf.Timestamp} Timestamp instance
+             */
+            Timestamp.create = function create(properties) {
+                return new Timestamp(properties);
+            };
 
-      /**
-       * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
-       * @function encode
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
-       * @param {$protobuf.Writer} [writer] Writer to encode to
-       * @returns {$protobuf.Writer} Writer
-       */
-      Timestamp.encode = function encode(message, writer) {
-        if (!writer) {
-          writer = $Writer.create();
-        }
-        if (message.seconds != null && message.hasOwnProperty("seconds")) {
-          writer.uint32(/* id 1, wireType 0 = */ 8).int64(message.seconds);
-        }
-        if (message.nanos != null && message.hasOwnProperty("nanos")) {
-          writer.uint32(/* id 2, wireType 0 = */ 16).int32(message.nanos);
-        }
-        return writer;
-      };
+            /**
+             * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Timestamp.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
+                return writer;
+            };
 
-      /**
-       * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
-       * @function encodeDelimited
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
-       * @param {$protobuf.Writer} [writer] Writer to encode to
-       * @returns {$protobuf.Writer} Writer
-       */
-      Timestamp.encodeDelimited = function encodeDelimited(message, writer) {
-        return this.encode(message, writer).ldelim();
-      };
+            /**
+             * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Timestamp.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
 
-      /**
-       * Decodes a Timestamp message from the specified reader or buffer.
-       * @function decode
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-       * @param {number} [length] Message length if known beforehand
-       * @returns {google.protobuf.Timestamp} Timestamp
-       * @throws {Error} If the payload is not a reader or valid buffer
-       * @throws {$protobuf.util.ProtocolError} If required fields are missing
-       */
-      Timestamp.decode = function decode(reader, length) {
-        if (!(reader instanceof $Reader)) {
-          reader = $Reader.create(reader);
-        }
-        var end = length === undefined ? reader.len : reader.pos + length;
-        var message = new $root.google.protobuf.Timestamp();
-        while (reader.pos < end) {
-          var tag = reader.uint32();
-          switch (tag >>> 3) {
-            case 1:
-              message.seconds = reader.int64();
-              break;
-            case 2:
-              message.nanos = reader.int32();
-              break;
-            default:
-              reader.skipType(tag & 7);
-              break;
-          }
-        }
-        return message;
-      };
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.Timestamp} Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Timestamp.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Timestamp();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.seconds = reader.int64();
+                        break;
+                    case 2:
+                        message.nanos = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
 
-      /**
-       * Decodes a Timestamp message from the specified reader or buffer, length delimited.
-       * @function decodeDelimited
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-       * @returns {google.protobuf.Timestamp} Timestamp
-       * @throws {Error} If the payload is not a reader or valid buffer
-       * @throws {$protobuf.util.ProtocolError} If required fields are missing
-       */
-      Timestamp.decodeDelimited = function decodeDelimited(reader) {
-        if (!(reader instanceof $Reader)) {
-          reader = new $Reader(reader);
-        }
-        return this.decode(reader, reader.uint32());
-      };
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.Timestamp} Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Timestamp.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
 
-      /**
-       * Verifies a Timestamp message.
-       * @function verify
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {Object.<string,*>} message Plain object to verify
-       * @returns {string|null} `null` if valid, otherwise the reason why it is not
-       */
-      Timestamp.verify = function verify(message) {
-        if (typeof message !== "object" || message === null) {
-          return "object expected";
-        }
-        if (message.seconds != null && message.hasOwnProperty("seconds")) {
-          if (
-            !$util.isInteger(message.seconds) &&
-            !(
-              message.seconds &&
-              $util.isInteger(message.seconds.low) &&
-              $util.isInteger(message.seconds.high)
-            )
-          ) {
-            return "seconds: integer|Long expected";
-          }
-        }
-        if (message.nanos != null && message.hasOwnProperty("nanos")) {
-          if (!$util.isInteger(message.nanos)) {
-            return "nanos: integer expected";
-          }
-        }
-        return null;
-      };
+            /**
+             * Verifies a Timestamp message.
+             * @function verify
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            Timestamp.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
+                        return "seconds: integer|Long expected";
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    if (!$util.isInteger(message.nanos))
+                        return "nanos: integer expected";
+                return null;
+            };
 
-      /**
-       * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
-       * @function fromObject
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {Object.<string,*>} object Plain object
-       * @returns {google.protobuf.Timestamp} Timestamp
-       */
-      Timestamp.fromObject = function fromObject(object) {
-        if (object instanceof $root.google.protobuf.Timestamp) {
-          return object;
-        }
-        var message = new $root.google.protobuf.Timestamp();
-        if (object.seconds != null) {
-          if ($util.Long) {
-            (message.seconds = $util.Long.fromValue(
-              object.seconds
-            )).unsigned = false;
-          } else if (typeof object.seconds === "string") {
-            message.seconds = parseInt(object.seconds, 10);
-          } else if (typeof object.seconds === "number") {
-            message.seconds = object.seconds;
-          } else if (typeof object.seconds === "object") {
-            message.seconds = new $util.LongBits(
-              object.seconds.low >>> 0,
-              object.seconds.high >>> 0
-            ).toNumber();
-          }
-        }
-        if (object.nanos != null) {
-          message.nanos = object.nanos | 0;
-        }
-        return message;
-      };
+            /**
+             * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.Timestamp} Timestamp
+             */
+            Timestamp.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.Timestamp)
+                    return object;
+                var message = new $root.google.protobuf.Timestamp();
+                if (object.seconds != null)
+                    if ($util.Long)
+                        (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
+                    else if (typeof object.seconds === "string")
+                        message.seconds = parseInt(object.seconds, 10);
+                    else if (typeof object.seconds === "number")
+                        message.seconds = object.seconds;
+                    else if (typeof object.seconds === "object")
+                        message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
+                if (object.nanos != null)
+                    message.nanos = object.nanos | 0;
+                return message;
+            };
 
-      /**
-       * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
-       * @function toObject
-       * @memberof google.protobuf.Timestamp
-       * @static
-       * @param {google.protobuf.Timestamp} message Timestamp
-       * @param {$protobuf.IConversionOptions} [options] Conversion options
-       * @returns {Object.<string,*>} Plain object
-       */
-      Timestamp.toObject = function toObject(message, options) {
-        if (!options) {
-          options = {};
-        }
-        var object = {};
-        if (options.defaults) {
-          if ($util.Long) {
-            var long = new $util.Long(0, 0, false);
-            object.seconds =
-              options.longs === String
-                ? long.toString()
-                : options.longs === Number
-                ? long.toNumber()
-                : long;
-          } else {
-            object.seconds = options.longs === String ? "0" : 0;
-          }
-          object.nanos = 0;
-        }
-        if (message.seconds != null && message.hasOwnProperty("seconds")) {
-          if (typeof message.seconds === "number") {
-            object.seconds =
-              options.longs === String
-                ? String(message.seconds)
-                : message.seconds;
-          } else {
-            object.seconds =
-              options.longs === String
-                ? $util.Long.prototype.toString.call(message.seconds)
-                : options.longs === Number
-                ? new $util.LongBits(
-                    message.seconds.low >>> 0,
-                    message.seconds.high >>> 0
-                  ).toNumber()
-                : message.seconds;
-          }
-        }
-        if (message.nanos != null && message.hasOwnProperty("nanos")) {
-          object.nanos = message.nanos;
-        }
-        return object;
-      };
+            /**
+             * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.Timestamp} message Timestamp
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            Timestamp.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.seconds = options.longs === String ? "0" : 0;
+                    object.nanos = 0;
+                }
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    if (typeof message.seconds === "number")
+                        object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
+                    else
+                        object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    object.nanos = message.nanos;
+                return object;
+            };
 
-      /**
-       * Converts this Timestamp to JSON.
-       * @function toJSON
-       * @memberof google.protobuf.Timestamp
-       * @instance
-       * @returns {Object.<string,*>} JSON object
-       */
-      Timestamp.prototype.toJSON = function toJSON() {
-        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-      };
+            /**
+             * Converts this Timestamp to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.Timestamp
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            Timestamp.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
 
-      return Timestamp;
+            return Timestamp;
+        })();
+
+        return protobuf;
     })();
 
-    return protobuf;
-  })();
-
-  return google;
+    return google;
 })();
 
 module.exports = $root;

--- a/src/proto/logproto.proto
+++ b/src/proto/logproto.proto
@@ -2,104 +2,130 @@ syntax = "proto3";
 
 package logproto;
 
+option go_package = "github.com/grafana/loki/pkg/logproto";
+
 import "google/protobuf/timestamp.proto";
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 service Pusher {
-  rpc Push(PushRequest) returns (PushResponse) {};
+    rpc Push(PushRequest) returns (PushResponse) {};
 }
 
 service Querier {
-  rpc Query(QueryRequest) returns (stream QueryResponse) {};
-  rpc Label(LabelRequest) returns (LabelResponse) {};
-  rpc Tail(TailRequest) returns (stream TailResponse) {};
+    rpc Query(QueryRequest) returns (stream QueryResponse) {};
+    rpc Label(LabelRequest) returns (LabelResponse) {};
+    rpc Tail(TailRequest) returns (stream TailResponse) {};
+    rpc Series(SeriesRequest) returns (SeriesResponse) {};
+    rpc TailersCount(TailersCountRequest) returns (TailersCountResponse) {};
 }
 
 service Ingester {
-  rpc TransferChunks(stream TimeSeriesChunk) returns (TransferChunksResponse) {};
+    rpc TransferChunks(stream TimeSeriesChunk) returns (TransferChunksResponse) {};
 }
 
 message PushRequest {
-  repeated Stream streams = 1 [(gogoproto.jsontag) = "streams"];
+    repeated Stream streams = 1 [(gogoproto.jsontag) = "streams"];
 }
 
 message PushResponse {
 }
 
 message QueryRequest {
-  string selector = 1;
-  uint32 limit = 2;
-  google.protobuf.Timestamp start = 3 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
-  google.protobuf.Timestamp end = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
-  Direction direction = 5;
-  reserved 6;
+    string selector = 1;
+    uint32 limit = 2;
+    google.protobuf.Timestamp start = 3 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp end = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    Direction direction = 5;
+    reserved 6;
 }
 
 enum Direction {
-  FORWARD = 0;
-  BACKWARD = 1;
+    FORWARD = 0;
+    BACKWARD = 1;
 }
 
 message QueryResponse {
-  repeated Stream streams = 1;
+    repeated Stream streams = 1;
 }
 
 message LabelRequest {
-  string name = 1;
-  bool values = 2; // True to fetch label values, false for fetch labels names.
-  google.protobuf.Timestamp start = 3 [(gogoproto.stdtime) = true, (gogoproto.nullable) = true];
-  google.protobuf.Timestamp end = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = true];
+    string name = 1;
+    bool values = 2; // True to fetch label values, false for fetch labels names.
+    google.protobuf.Timestamp start = 3 [(gogoproto.stdtime) = true, (gogoproto.nullable) = true];
+    google.protobuf.Timestamp end = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = true];
 }
 
 message LabelResponse {
-  repeated string values = 1;
+    repeated string values = 1;
 }
 
 message Stream {
-  string labels = 1 [(gogoproto.jsontag) = "labels"];
-  repeated Entry entries = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "entries"];
+    string labels = 1 [(gogoproto.jsontag) = "labels"];
+    repeated Entry entries = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "entries"];
 }
 
 message Entry {
-  google.protobuf.Timestamp timestamp = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (gogoproto.jsontag) = "ts"];
-  string line = 2 [(gogoproto.jsontag) = "line"];
+    google.protobuf.Timestamp timestamp = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (gogoproto.jsontag) = "ts"];
+    string line = 2 [(gogoproto.jsontag) = "line"];
 }
 
 message TailRequest {
-  string query = 1;
-  reserved 2;
-  uint32 delayFor = 3;
-  uint32 limit = 4;
-  google.protobuf.Timestamp start = 5 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    string query = 1;
+    reserved 2;
+    uint32 delayFor = 3;
+    uint32 limit = 4;
+    google.protobuf.Timestamp start = 5 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
 }
 
 message TailResponse {
-  Stream stream = 1;
-  repeated DroppedStream droppedStreams = 2;
+    Stream stream = 1;
+    repeated DroppedStream droppedStreams = 2;
+}
+
+message SeriesRequest {
+    google.protobuf.Timestamp start = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp end = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    repeated string groups = 3;
+}
+
+message SeriesResponse {
+    repeated SeriesIdentifier series = 1 [(gogoproto.nullable) = false];
+}
+
+message SeriesIdentifier {
+    map<string,string> labels = 1;
 }
 
 message DroppedStream {
-  google.protobuf.Timestamp from = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
-  google.protobuf.Timestamp to = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
-  string labels = 3;
+    google.protobuf.Timestamp from = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp to = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    string labels = 3;
 }
 
 message TimeSeriesChunk {
-  string from_ingester_id = 1;
-  string user_id = 2;
-  repeated LabelPair labels = 3;
-  repeated Chunk chunks = 4;
+    string from_ingester_id = 1;
+    string user_id = 2;
+    repeated LabelPair labels = 3;
+    repeated Chunk chunks = 4;
 }
 
 message LabelPair {
-  string name = 1;
-  string value = 2;
+    string name = 1;
+    string value = 2;
 }
 
 message Chunk {
-  bytes data = 1;
+    bytes data = 1;
 }
 
 message TransferChunksResponse {
 
+}
+
+message TailersCountRequest {
+
+}
+
+message TailersCountResponse {
+    uint32 count = 1;
 }

--- a/src/requests.js
+++ b/src/requests.js
@@ -2,12 +2,11 @@ const http = require('http')
 const https = require('https')
 
 const post = async (lokiUrl, contentType, data) => {
-  console.log(lokiUrl)
   return new Promise((resolve, reject) => {
     const lib = lokiUrl.protocol === 'https:' ? https : http
     const options = {
       hostname: lokiUrl.hostname,
-      port: lokiUrl.port === '' ? 80 : 443,
+      port: lokiUrl.port !== '' ? lokiUrl.port : (lokiUrl.protocol === 'https:' ? 443 : 80),
       path: lokiUrl.pathname,
       method: 'POST',
       headers: {
@@ -16,9 +15,9 @@ const post = async (lokiUrl, contentType, data) => {
       }
     }
     const req = lib.request(options, res => {
-      res.on('data', response => {
-        resolve(response)
-      })
+      let resData = ''
+      res.on('data', _data => (resData += _data))
+      res.on('end', () => resolve(resData))
     })
     req.on('error', error => {
       reject(error)

--- a/src/requests.js
+++ b/src/requests.js
@@ -6,6 +6,7 @@ const post = async (lokiUrl, contentType, headers = {}, data = '') => {
     'Content-Type': contentType,
     'Content-Length': data.length
   }
+  console.log(data)
   return new Promise((resolve, reject) => {
     const lib = lokiUrl.protocol === 'https:' ? https : http
     const options = {

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,7 +1,11 @@
 const http = require('http')
 const https = require('https')
 
-const post = async (lokiUrl, contentType, data) => {
+const post = async (lokiUrl, contentType, headers = {}, data = '') => {
+  const defaultHeaders = {
+    'Content-Type': contentType,
+    'Content-Length': data.length
+  }
   return new Promise((resolve, reject) => {
     const lib = lokiUrl.protocol === 'https:' ? https : http
     const options = {
@@ -9,10 +13,7 @@ const post = async (lokiUrl, contentType, data) => {
       port: lokiUrl.port !== '' ? lokiUrl.port : (lokiUrl.protocol === 'https:' ? 443 : 80),
       path: lokiUrl.pathname,
       method: 'POST',
-      headers: {
-        'Content-Type': contentType,
-        'Content-Length': data.length
-      }
+      headers: Object.assign(defaultHeaders, headers)
     }
     const req = lib.request(options, res => {
       let resData = ''

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,0 +1,31 @@
+const http = require('http')
+const https = require('https')
+
+const post = async (lokiUrl, contentType, data) => {
+  console.log(lokiUrl)
+  return new Promise((resolve, reject) => {
+    const lib = lokiUrl.protocol === 'https:' ? https : http
+    const options = {
+      hostname: lokiUrl.hostname,
+      port: lokiUrl.port === '' ? 80 : 443,
+      path: lokiUrl.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': data.length
+      }
+    }
+    const req = lib.request(options, res => {
+      res.on('data', response => {
+        resolve(response)
+      })
+    })
+    req.on('error', error => {
+      reject(error)
+    })
+    req.write(data)
+    req.end()
+  })
+}
+
+module.exports = { post }

--- a/src/requests.js
+++ b/src/requests.js
@@ -6,7 +6,6 @@ const post = async (lokiUrl, contentType, headers = {}, data = '') => {
     'Content-Type': contentType,
     'Content-Length': data.length
   }
-  console.log(data)
   return new Promise((resolve, reject) => {
     const lib = lokiUrl.protocol === 'https:' ? https : http
     const options = {

--- a/test/batcher.json.test.js
+++ b/test/batcher.json.test.js
@@ -51,7 +51,7 @@ describe('Batcher tests with JSON transport', function () {
     await stub.mockReturnValue(() => call())
     const spy = jest.fn(call)
 
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
 
     function call () {
       expect(spy).toHaveBeenCalledTimes(1)
@@ -59,22 +59,22 @@ describe('Batcher tests with JSON transport', function () {
     await stub.mockRestore()
   })
   it('Should add same items in the same stream', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
     expect(batcher.batch.streams.length).toBe(1)
   })
   it('Should add items with same labels in the same stream', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[2]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[1]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[2]))
     expect(batcher.batch.streams.length).toBe(1)
   })
   it('Should add items with different labels in separate streams', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[2]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[2]))
     expect(batcher.batch.streams.length).toBe(2)
   })
   it('Should replace timestamps with Date.now() if replaceTimestamp is enabled', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[1]))
 
     expect(batcher.batch.streams[0].entries[0].ts).toBe(
       fixtures.logs[1].timestamp
@@ -84,15 +84,15 @@ describe('Batcher tests with JSON transport', function () {
     options.replaceTimestamp = true
     batcher = new Batcher(options)
 
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[1]))
 
     expect(batcher.batch.streams[0].entries[0].ts).not.toBe(
       fixtures.logs[1].timestamp
     )
   })
   it('Should be able to clear the batch of streams', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[2]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[2]))
     expect(batcher.batch.streams.length).toBe(2)
     batcher.clearBatch()
     expect(batcher.batch.streams.length).toBe(0)
@@ -108,10 +108,10 @@ describe('Batcher tests with JSON transport', function () {
       }
     }
     req.post.mockResolvedValue(responseObject)
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
+    batcher.pushLogEntry(fixtures.logs[1])
 
     expect(req.post.mock.calls[0][req.post.mock.calls[0].length - 1]).toBe(
-      JSON.stringify({ streams: [JSON.parse(fixtures.logs_mapped[1])] })
+      JSON.stringify({ streams: [JSON.parse(fixtures.logs_mapped_after[1])] })
     )
   })
   it('Should clear batch and resolve on successful send', async function () {
@@ -122,14 +122,14 @@ describe('Batcher tests with JSON transport', function () {
       }
     }
     req.post.mockResolvedValue(responseObject)
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(fixtures.logs[0])
 
     expect(batcher.batch.streams.length).toBe(1)
 
     await batcher.sendBatchToLoki()
 
     expect(req.post.mock.calls[0][req.post.mock.calls[0].length - 1]).toBe(
-      JSON.stringify({ streams: [JSON.parse(fixtures.logs_mapped[0])] })
+      JSON.stringify({ streams: [JSON.parse(fixtures.logs_mapped_after[0])] })
     )
     expect(batcher.batch.streams.length).toBe(0)
   })
@@ -138,7 +138,7 @@ describe('Batcher tests with JSON transport', function () {
       statusCode: 404
     }
     req.post.mockRejectedValue(errorObject)
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
     expect(batcher.batch.streams.length).toBe(1)
     try {
       await batcher.sendBatchToLoki()
@@ -156,7 +156,7 @@ describe('Batcher tests with JSON transport', function () {
       statusCode: 404
     }
     req.post.mockRejectedValue(errorObject)
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
     expect(batcher.batch.streams.length).toBe(1)
 
     try {
@@ -193,7 +193,7 @@ describe('Batcher tests with JSON transport', function () {
 
     batcher.circuitBreakerInterval = circuitBreakerInterval
     batcher.run()
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(fixtures.logs[0])
 
     expect(batcher.batch.streams.length).toBe(1)
     expect(batcher.interval).toBe(fixtures.options_json.interval * 1000)

--- a/test/batcher.json.test.js
+++ b/test/batcher.json.test.js
@@ -1,5 +1,5 @@
 const Batcher = require('../src/batcher')
-const got = require('got')
+const req = require('../src/requests')
 const fixtures = require('./fixtures.json')
 
 let batcher
@@ -8,13 +8,13 @@ describe('Batcher tests with JSON transport', function () {
   beforeEach(async function () {
     jest.resetModules()
     batcher = new Batcher(fixtures.options_json)
-    got.post = await jest
-      .spyOn(got, 'post')
+    req.post = await jest
+      .spyOn(req, 'post')
       .mockImplementation(() => Promise.resolve())
   })
   afterEach(function () {
     batcher.clearBatch()
-    got.post.mockRestore()
+    req.post.mockRestore()
   })
   it('Should construct with default interval if one is not given', function () {
     const options = JSON.parse(JSON.stringify(fixtures.options_json))
@@ -107,10 +107,10 @@ describe('Batcher tests with JSON transport', function () {
         'content-type': 'application/json'
       }
     }
-    got.post.mockResolvedValue(responseObject)
+    req.post.mockResolvedValue(responseObject)
     batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
 
-    expect(got.post.mock.calls[0][got.post.mock.calls[0].length - 1].body).toBe(
+    expect(req.post.mock.calls[0][req.post.mock.calls[0].length - 1]).toBe(
       JSON.stringify({ streams: [JSON.parse(fixtures.logs_mapped[1])] })
     )
   })
@@ -121,14 +121,14 @@ describe('Batcher tests with JSON transport', function () {
         'content-type': 'application/json'
       }
     }
-    got.post.mockResolvedValue(responseObject)
+    req.post.mockResolvedValue(responseObject)
     batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
 
     expect(batcher.batch.streams.length).toBe(1)
 
     await batcher.sendBatchToLoki()
 
-    expect(got.post.mock.calls[0][got.post.mock.calls[0].length - 1].body).toBe(
+    expect(req.post.mock.calls[0][req.post.mock.calls[0].length - 1]).toBe(
       JSON.stringify({ streams: [JSON.parse(fixtures.logs_mapped[0])] })
     )
     expect(batcher.batch.streams.length).toBe(0)
@@ -137,7 +137,7 @@ describe('Batcher tests with JSON transport', function () {
     const errorObject = {
       statusCode: 404
     }
-    got.post.mockRejectedValue(errorObject)
+    req.post.mockRejectedValue(errorObject)
     batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
     expect(batcher.batch.streams.length).toBe(1)
     try {
@@ -155,7 +155,7 @@ describe('Batcher tests with JSON transport', function () {
     const errorObject = {
       statusCode: 404
     }
-    got.post.mockRejectedValue(errorObject)
+    req.post.mockRejectedValue(errorObject)
     batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
     expect(batcher.batch.streams.length).toBe(1)
 
@@ -174,7 +174,7 @@ describe('Batcher tests with JSON transport', function () {
         'content-type': 'application/json'
       }
     }
-    got.post.mockResolvedValue(responseObject)
+    req.post.mockResolvedValue(responseObject)
     batcher.pushLogEntry(fixtures.incorrectly_mapped)
     try {
       await batcher.sendBatchToLoki()
@@ -186,7 +186,7 @@ describe('Batcher tests with JSON transport', function () {
     const errorObject = {
       statusCode: 404
     }
-    got.post.mockRejectedValue(errorObject)
+    req.post.mockRejectedValue(errorObject)
 
     const circuitBreakerInterval = fixtures.options_json.interval * 1000 * 1.01
     const waitFor = fixtures.options_json.interval * 1000 * 1.05
@@ -209,7 +209,7 @@ describe('Batcher tests with JSON transport', function () {
         'content-type': 'application/json'
       }
     }
-    got.post.mockResolvedValue(responseObject)
+    req.post.mockResolvedValue(responseObject)
 
     await batcher.wait(waitFor)
 

--- a/test/batcher.protobuf.test.js
+++ b/test/batcher.protobuf.test.js
@@ -83,14 +83,13 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
       }
     }
     req.post.mockResolvedValue(responseObject)
-    await batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[1]))
+    await batcher.pushLogEntry(fixtures.logs[1])
 
     const logEntryConverted = createProtoTimestamps(
-      JSON.parse(fixtures.logs_mapped[1])
+      fixtures.logs[1]
     )
-    const buffer = logproto.PushRequest.encode({
-      streams: [logEntryConverted]
-    }).finish()
+    const preparedLogEntry = prepareProtoBatch({ streams: [ logEntryConverted ] })
+    const buffer = logproto.PushRequest.encode(preparedLogEntry).finish()
 
     const snappy = require('snappy')
     const data = snappy.compressSync(buffer)

--- a/test/batcher.protobuf.test.js
+++ b/test/batcher.protobuf.test.js
@@ -3,7 +3,7 @@ const req = require('../src/requests')
 const { logproto } = require('../src/proto')
 const fixtures = require('./fixtures.json')
 
-const { createProtoTimestamps } = require('../src/proto/helpers')
+const { createProtoTimestamps, prepareProtoBatch } = require('../src/proto/helpers')
 
 let batcher
 
@@ -20,13 +20,13 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
     req.post.mockRestore()
   })
   it('Should add same items in the same stream', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
     expect(batcher.batch.streams.length).toBe(1)
   })
   it('Should add items with same labels in the same stream', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[2]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[1]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[2]))
     expect(batcher.batch.streams.length).toBe(1)
   })
   it('Should convert the timestamps on push when batching is disabled', async function () {
@@ -35,17 +35,18 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
     batcher = new Batcher(options)
 
     const logEntryConverted = createProtoTimestamps(
-      JSON.parse(fixtures.logs_mapped[1])
+      fixtures.logs[1]
     )
+    const preparedLogEntry = prepareProtoBatch({ streams: [ logEntryConverted ] })
     const stub = await jest.spyOn(batcher, 'sendBatchToLoki')
 
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
-    expect(stub).toHaveBeenCalledWith(logEntryConverted)
+    batcher.pushLogEntry(fixtures.logs[1])
+    expect(stub).toHaveBeenCalledWith(preparedLogEntry)
     stub.mockRestore()
   })
   it('Should be able to clear the batch of streams', function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[2]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[0]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[2]))
     expect(batcher.batch.streams.length).toBe(2)
     batcher.clearBatch()
     expect(batcher.batch.streams.length).toBe(0)
@@ -59,7 +60,7 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
     }
   })
   it("Should fail if snappy can't compress the buffer", async function () {
-    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[2]))
+    batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[2]))
     this.finish = await jest.spyOn(
       logproto.PushRequest.encode(batcher.batch),
       'finish'
@@ -82,7 +83,7 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
       }
     }
     req.post.mockResolvedValue(responseObject)
-    await batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
+    await batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped_before[1]))
 
     const logEntryConverted = createProtoTimestamps(
       JSON.parse(fixtures.logs_mapped[1])

--- a/test/batcher.protobuf.test.js
+++ b/test/batcher.protobuf.test.js
@@ -1,5 +1,5 @@
 const Batcher = require('../src/batcher')
-const got = require('got')
+const req = require('../src/requests')
 const { logproto } = require('../src/proto')
 const fixtures = require('./fixtures.json')
 
@@ -11,13 +11,13 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
   beforeEach(async function () {
     jest.resetModules()
     batcher = new Batcher(fixtures.options_protobuf)
-    got.post = await jest
-      .spyOn(got, 'post')
+    req.post = await jest
+      .spyOn(req, 'post')
       .mockImplementation(() => Promise.resolve())
   })
   afterEach(function () {
     batcher.clearBatch()
-    got.post.mockRestore()
+    req.post.mockRestore()
   })
   it('Should add same items in the same stream', function () {
     batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[0]))
@@ -81,7 +81,7 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
         'content-type': 'application/json'
       }
     }
-    got.post.mockResolvedValue(responseObject)
+    req.post.mockResolvedValue(responseObject)
     await batcher.pushLogEntry(JSON.parse(fixtures.logs_mapped[1]))
 
     const logEntryConverted = createProtoTimestamps(
@@ -94,7 +94,7 @@ describe('Batcher tests with Protobuf + gRPC transport', function () {
     const snappy = require('snappy')
     const data = snappy.compressSync(buffer)
     expect(
-      got.post.mock.calls[0][got.post.mock.calls[0].length - 1].body
+      req.post.mock.calls[0][req.post.mock.calls[0].length - 1]
     ).toEqual(data)
   })
   it('Should construct without snappy binaries to a JSON transport', function () {

--- a/test/custom-labels-lines.test.js
+++ b/test/custom-labels-lines.test.js
@@ -47,7 +47,7 @@ describe('Integration tests', function () {
     const testMessage = 'testMessage'
     const testLabel = 'testLabel'
     const now = Date.now() / 1000
-    logger.debug({ message: testMessage, labels: { 'customLabel': testLabel } })
+    logger.debug({ message: testMessage, labels: { customLabel: testLabel } })
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(
       lokiTransport.batcher.batch.streams[0]

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -33,10 +33,10 @@
     }
   ],
   "logs_mapped": [
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"entries\":[{\"ts\":1546977515828,\"line\":\"testings \"}]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything \"} ]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything but not quite \"}]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977515858,\"line\":\"you broke everything but not quite {\\\"jeejee\\\":\\\"ebon\\\"}\"}]}"
+    "{\"stream\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"values\":[1546977515828,\"testings \"]}",
+    "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything \"]}",
+    "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything but not quite \"]}",
+    "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977515858,\"you broke everything but not quite {\\\"jeejee\\\":\\\"ebon\\\"}\"]}"
   ],
   "incorrect_mapping": "{ \"labelings\": \"{jobbings=\\\"test\\\", levelings=\\\"info\\\"}\", \"entries\": [ { \"tisisnotit\": 1546977515828, \"dontdodisline\": \"testings {}\" } ] }"
 }

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -29,19 +29,21 @@
       "timestamp": 1546977515858,
       "message": "you broke everything but not quite",
       "level": "error",
-      "jeejee": "ebon"
+      "labels": {
+        "jeejee": "ebon"
+      }
     }
   ],
   "logs_mapped_before": [
     "{\"labels\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"entries\":[{\"ts\":1546977515828,\"line\":\"testings \"}]}",
     "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything \"} ]}",
     "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything but not quite \"}]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977515858,\"line\":\"you broke everything but not quite {\\\"jeejee\\\":\\\"ebon\\\"}\"}]}"],
+    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\", jeejee=\\\"ebon\\\"}\",\"entries\":[{\"ts\":1546977515858,\"line\":\"you broke everything but not quite \"]}"],
   "logs_mapped_after": [
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"values\":[1546977515828,\"testings \"]}",
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything \"]}",
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything but not quite \"]}",
-    "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977515858,\"you broke everything but not quite {\\\"jeejee\\\":\\\"ebon\\\"}\"]}"
+    "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\", jeejee=\\\"ebon\\\"}\",\"values\":[1546977515858,\"you broke everything but not quite \"]}"
   ],
   "incorrect_mapping": "{ \"labelings\": \"{jobbings=\\\"test\\\", levelings=\\\"info\\\"}\", \"entries\": [ { \"tisisnotit\": 1546977515828, \"dontdodisline\": \"testings {}\" } ] }"
 }

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -32,7 +32,12 @@
       "jeejee": "ebon"
     }
   ],
-  "logs_mapped": [
+  "logs_mapped_before": [
+    "{\"labels\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"entries\":[{\"ts\":1546977515828,\"line\":\"testings \"}]}",
+    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything \"} ]}",
+    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything but not quite \"}]}",
+    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977515858,\"line\":\"you broke everything but not quite {\\\"jeejee\\\":\\\"ebon\\\"}\"}]}"],
+  "logs_mapped_after": [
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"values\":[1546977515828,\"testings \"]}",
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything \"]}",
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything but not quite \"]}",

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -1,0 +1,79 @@
+const req = require('../src/requests')
+const url = require('url')
+const http = require('http')
+jest.mock('http')
+const https = require('https')
+jest.mock('https')
+
+const httpUrl = new url.URL('http://localhost:3000' + '/api/prom/push')
+const httpsUrl = new url.URL('https://localhost:3000' + '/api/prom/push')
+const leanUrl = new url.URL('https://localhost' + '/api/prom/push')
+const leanUrl2 = new url.URL('http://localhost' + '/api/prom/push')
+const testData = 'test'
+const httpsPort = 443
+const httpPort = 80
+
+const httpOptions = {
+  hostname: httpUrl.hostname,
+  port: httpUrl.port !== '' ? httpUrl.port : (httpUrl.protocol === 'https:' ? httpsPort : httpPort),
+  path: httpUrl.pathname,
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': testData.length
+  }
+}
+
+const httpsOptions = {
+  hostname: httpsUrl.hostname,
+  port: httpsUrl.port !== '' ? httpsUrl.port : (httpsUrl.protocol === 'https:' ? httpsPort : httpPort),
+  path: httpsUrl.pathname,
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': testData.length
+  }
+}
+
+const mockedRequest = {
+  write: () => console.log('called!'),
+  end: () => console.log('end called!'),
+  on: eventName => jest.fn(done => done())
+}
+
+const mockedResponse = (options, callback) => {
+  const incomingMessage = new http.IncomingMessage()
+  callback(incomingMessage)
+  incomingMessage.emit('data', testData)
+  incomingMessage.emit('end')
+  return mockedRequest
+}
+
+describe('Requests tests', function () {
+  it('Should return promise', function () {
+    http.request.mockImplementation(mockedResponse)
+    https.request.mockImplementation(mockedResponse)
+    const promise = req.post(httpUrl, httpOptions.headers['Content-Type'], testData)
+    expect(typeof promise).toBe('object')
+    expect(typeof promise.then).toBe('function')
+    expect(
+      http.request.mock.calls[0][0]
+    ).toEqual(httpOptions)
+    req.post(leanUrl, httpOptions.headers['Content-Type'], testData)
+    expect(
+      https.request.mock.calls[0][0].port
+    ).toEqual(httpsPort)
+    req.post(leanUrl2, httpOptions.headers['Content-Type'], testData)
+    expect(
+      http.request.mock.calls[1][0].port
+    ).toEqual(httpPort)
+  })
+  it('Should read config correctly', async function () {
+    let response = await req.post(httpsUrl, httpsOptions.headers['Content-Type'], testData)
+    console.log(response)
+    expect(
+      https.request.mock.calls[1][0]
+    ).toEqual(httpsOptions)
+    expect(response).not.toBe(undefined)
+  })
+})

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -36,9 +36,9 @@ const httpsOptions = {
 }
 
 const mockedRequest = {
-  write: () => console.log('called!'),
-  end: () => console.log('end called!'),
-  on: eventName => jest.fn(done => done())
+  write: () => null,
+  end: () => null,
+  on: () => jest.fn(done => done())
 }
 
 const mockedResponse = (options, callback) => {

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -53,7 +53,7 @@ describe('Requests tests', function () {
   it('Should return promise', function () {
     http.request.mockImplementation(mockedResponse)
     https.request.mockImplementation(mockedResponse)
-    const promise = req.post(httpUrl, httpOptions.headers['Content-Type'], testData)
+    const promise = req.post(httpUrl, httpOptions.headers['Content-Type'], {}, testData)
     expect(typeof promise).toBe('object')
     expect(typeof promise.then).toBe('function')
     expect(
@@ -68,12 +68,8 @@ describe('Requests tests', function () {
       http.request.mock.calls[1][0].port
     ).toEqual(httpPort)
   })
-  it('Should read config correctly', async function () {
-    let response = await req.post(httpsUrl, httpsOptions.headers['Content-Type'], testData)
-    console.log(response)
-    expect(
-      https.request.mock.calls[1][0]
-    ).toEqual(httpsOptions)
-    expect(response).not.toBe(undefined)
+  it('Should be able to run https and http', () => {
+    const promise = req.post(httpsUrl, httpsOptions.headers['Content-Type'], {}, testData)
+    expect(typeof promise).toBe('object')
   })
 })

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -39,14 +39,14 @@ describe('Integration tests', function () {
     const lokiTransport = new LokiTransport(fixtures.options_json)
     const spy = jest.spyOn(lokiTransport.batcher, 'pushLogEntry')
     lokiTransport.log(fixtures.logs[0], () => {})
-    expect(spy).toHaveBeenCalledWith(JSON.parse(fixtures.logs_mapped[0]))
+    expect(spy).toHaveBeenCalledWith(JSON.parse(fixtures.logs_mapped_before[0]))
   })
   it('LokiTransport should map logs correctly from Winston to Grafana Loki format', function () {
     const lokiTransport = new LokiTransport(fixtures.options_json)
     lokiTransport.log(fixtures.logs[0], () => {})
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(lokiTransport.batcher.batch.streams[0]).toEqual(
-      JSON.parse(fixtures.logs_mapped[0])
+      fixtures.logs[0]
     )
   })
   it("LokiTransport should append anything else than the message after it in the log's entry", function () {
@@ -55,7 +55,7 @@ describe('Integration tests', function () {
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(
       JSON.stringify(lokiTransport.batcher.batch.streams[0]).replace(/\s/g, '')
-    ).toEqual(fixtures.logs_mapped[3].replace(/\s/g, ''))
+    ).toEqual(fixtures.logs_mapped_before[3].replace(/\s/g, ''))
   })
   it('LokiTransport should not append anything else after the message if there are no extra keys in the log object', function () {
     const lokiTransport = new LokiTransport(fixtures.options_json)
@@ -63,6 +63,6 @@ describe('Integration tests', function () {
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(
       JSON.stringify(lokiTransport.batcher.batch.streams[0]).replace(/\s/g, '')
-    ).toEqual(fixtures.logs_mapped[2].replace(/\s/g, ''))
+    ).toEqual(fixtures.logs_mapped_before[2].replace(/\s/g, ''))
   })
 })


### PR DESCRIPTION
This is a major update, **no backwards compatibility with old Loki instances**.

### Changes:
- Removes `got` and `moment` dependencies, relying on the standard library.
- **BREAKING**: Updates the used endpoint from deprecated `/api/prom/push` to current `/loki/api/v1/push`
- Adds `./examples/` folder for example configurations and for debugging a running Loki instance

### Closes the following issues:
Fixes #24
Fixes #30 
Fixes #19 

### TODO:
- [ ] Update tests