### PR TITLE
fix: stop batcher loop on close

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,7 @@ class LokiTransport extends Transport {
    * Send batch to loki when clean up
    */
   close () {
-    this.batcher.sendBatchToLoki()
-      .then(() => {}) // maybe should emit something here
-      .catch(() => {}) // maybe should emit something here
+    this.batcher.close()
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "6.0.0-rc.3",
+  "version": "6.0.0-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -70,9 +70,7 @@ class Batcher {
 
     if (this.options.gracefulShutdown) {
       exitHook(callback => {
-        this.sendBatchToLoki()
-          .then(() => callback())
-          .catch(() => callback())
+        this.close(() => callback())
       })
     }
   }
@@ -219,7 +217,8 @@ class Batcher {
    * the amount of this.interval between requests.
    */
   async run () {
-    while (true) {
+    this.runLoop = true
+    while (this.runLoop) {
       try {
         await this.sendBatchToLoki()
         if (this.interval === this.circuitBreakerInterval) {
@@ -230,6 +229,18 @@ class Batcher {
       }
       await this.wait(this.interval)
     }
+  }
+
+  /**
+   * Stops the batch push loop
+   *
+   * @param {() => void} [callback]
+   */
+  close (callback) {
+    this.runLoop = false
+    this.sendBatchToLoki()
+      .then(() => { if (callback) { callback() } }) // maybe should emit something here
+      .catch(() => { if (callback) { callback() } }) // maybe should emit something here
   }
 }
 


### PR DESCRIPTION
I'm looking to make winston-loki an integral part of my logging system.

However, if batching mode is enabled, the batcher will start an infinite loop.

So I made minor tweaks to the `close()` hook so the infinite loop ends after its last cycle.

This small change made all the difference in having to kill my processes and having them exit gracefully after their last loop.