### PR TITLE
Incorrect Content-Length if payload has any UTF8 characters

### DIFF
--- a/src/requests.js
+++ b/src/requests.js
@@ -4,7 +4,7 @@ const https = require('https')
 const post = async (lokiUrl, contentType, headers = {}, data = '') => {
   const defaultHeaders = {
     'Content-Type': contentType,
-    'Content-Length': data.length
+    'Content-Length': Buffer.from(data, "utf8").length
   }
   return new Promise((resolve, reject) => {
     const lib = lokiUrl.protocol === 'https:' ? https : http


### PR DESCRIPTION
If message payload has any UTF8 character, the Content-Length calculated incorrectly.
It will be better also to write buffer into request, instead of string to make it be sure that length are equal.