### PR TITLE
Convert to correct nanoseconds

### DIFF
--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -5,7 +5,7 @@ module.exports = {
         return {
           timestamp: {
             seconds: Math.floor(entry.ts / 1000),
-            nanos: (entry.ts % 1000) * 1000
+            nanos: (entry.ts % 1000) * 1000000
           },
           line: entry.line
         }


### PR DESCRIPTION
`entry.ts % 1000` from a ms timestamp gives you only the milliseconds
If you multiply it by 1000 you will get microseconds
If you multiply that på 1000 again you will get nanoseconds.

I think you do the right conversion when sending as json, but without JSON, my Loki logs are missing milliseconds because the real milliseconds is translated as microseconds