### PR TITLE
Fix: Handle Promise rejection, when batching is turned off

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,10 @@ class LokiTransport extends Transport {
     }
 
     // Pushes the log to the batcher
-    this.batcher.pushLogEntry(logEntry)
+    this.batcher.pushLogEntry(logEntry).catch(err => {
+      // eslint-disable-next-line no-console
+      console.error(err)
+    })
 
     // Trigger the optional callback
     callback()

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1,5 +1,6 @@
 {
   "options_json": { "host": "http://localhost", "interval": 0.1, "json": true },
+  "options_no_batching": { "host": "http://localhost", "batching": false },
   "options_protobuf": {
     "host": "http://localhost",
     "interval": 0.1,

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -30,6 +30,22 @@ describe('Integration tests', function () {
     })
     expect(callback).toBe(true)
   })
+  it('LokiTransport shouldn\'t cause unhandledPromiseRejection when batching is turned off', async function () {
+    let consoleError = false
+    // eslint-disable-next-line no-console
+    console.error = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {
+        consoleError = true
+      })
+
+    const lokiTransport = new LokiTransport(fixtures.options_no_batching)
+    lokiTransport.log(fixtures.logs[0], () => {})
+
+    // Wait for Promise (this.batcher.pushLogEntry) be rejected
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(consoleError).toBe(true)
+  })
   it('LokiTransport should transfer logs to the Batcher', function () {
     const lokiTransport = new LokiTransport(fixtures.options_json)
     lokiTransport.log(fixtures.logs[0], () => {})


### PR DESCRIPTION
Preconditions:
- loki http endpoint is not reachable
- batching is turned off
- you are subscribed on unhandledRejection process event and use logger to log unhandled rejections, like:
```
process.on('unhandledRejection', error => logger.error(error));
```

Issue:
- loki transport causes infinity loop of 'unhandledRejection' events

Solution:
- Handle `this.batched. pushLogEntry` promise rejection in LokiTransport