### PR TITLE
fix: Solve [object Object] on all labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class LokiTransport extends Transport {
     }`
 
     // Make sure all label values are strings
-    lokiLabels = Object.fromEntries(Object.entries(lokiLabels).map(([key,value]) => [key, value ? value.toString() : value]))
+    lokiLabels = Object.fromEntries(Object.entries(lokiLabels).map(([key, value]) => [key, value ? value.toString() : value]))
 
     // Construct the log to fit Grafana Loki's accepted format
     const logEntry = {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class LokiTransport extends Transport {
     }`
 
     // Make sure all label values are strings
-    lokiLabels = JSON.parse(JSON.stringify(lokiLabels, (key, value) => value ? value.toString() : value))
+    lokiLabels = Object.fromEntries(Object.entries(lokiLabels).map(([key,value]) => [key, value ? value.toString() : value]))
 
     // Construct the log to fit Grafana Loki's accepted format
     const logEntry = {

--- a/test/custom-labels-lines.test.js
+++ b/test/custom-labels-lines.test.js
@@ -52,7 +52,7 @@ describe('Integration tests', function () {
     expect(
       lokiTransport.batcher.batch.streams[0]
     ).toEqual({
-      labels: `{level="debug",module="name",app="appname",customLabel="${testLabel}"}`,
+      labels: { level: 'debug', module: 'name', app: 'appname', customLabel: testLabel },
       entries: [{
         line: `[name] ${testMessage}`,
         timestamp: {

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -36,10 +36,10 @@
     }
   ],
   "logs_mapped_before": [
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"entries\":[{\"ts\":1546977515828,\"line\":\"testings \"}]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything \"} ]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything but not quite \"}]}",
-    "{\"labels\":\"{job=\\\"test\\\", level=\\\"error\\\", jeejee=\\\"ebon\\\"}\",\"entries\":[{\"ts\":1546977515858,\"line\":\"you broke everything but not quite \"]}"],
+    "{\"labels\":{\"job\":\"test\", \"level\":\"info\"},\"entries\":[{\"ts\":1546977515828,\"line\":\"testings \"}]}",
+    "{\"labels\":\"{\"job\":\"test\", \"level\":\"error\"}\",\"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything \"} ]}",
+    "{\"labels\":{\"level\":\"error\",\"job\":\"test\"}, \"entries\":[{\"ts\":1546977615848,\"line\":\"you broke everything but not quite \"}]}",
+    "{\"labels\":{\"level\":\"error\", \"jeejee\":\"ebon\", \"job\":\"test\"},\"entries\":[{\"ts\":1546977515858,\"line\":\"you broke everything but not quite \"}]}"],
   "logs_mapped_after": [
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"info\\\"}\",\"values\":[1546977515828,\"testings \"]}",
     "{\"stream\":\"{job=\\\"test\\\", level=\\\"error\\\"}\",\"values\":[1546977615848,\"you broke everything \"]}",

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -62,7 +62,16 @@ describe('Integration tests', function () {
     lokiTransport.log(fixtures.logs[0], () => {})
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(lokiTransport.batcher.batch.streams[0]).toEqual(
-      fixtures.logs[0]
+      {
+        entries: [{
+          line: 'testings ',
+          ts: 1546977515828
+        }],
+        'labels': {
+          job: 'test',
+          level: 'info'
+        }
+      }
     )
   })
   it("LokiTransport should append anything else than the message after it in the log's entry", function () {


### PR DESCRIPTION
I might be a wee bit impatient.

Here's my take to solve #81 

From Node REPL:
```
> Object.fromEntries(Object.entries(lokiLabels).map(([key,value]) => [key, value ? value.toString() : value]))
{ host: 'dev', env: 'test', key: 'value' }

> JSON.parse(JSON.stringify(lokiLabels, (key, value) => value ? value.toString() : value))
'[object Object]'
```

Fixes #81

I also tweaked a few related tests so there are less failing tests in a run.