### PR TITLE
fixed issue 68 by not modifying streams in-place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .coveralls.yml
 test/coverage
+
+/.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -14,17 +14,11 @@ module.exports = {
     return logEntry
   },
   prepareJSONBatch: batch => {
-    batch.streams = batch.streams.map(logEntry => {
-      logEntry.stream = logEntry.labels
-      logEntry.values = logEntry.entries
-      logEntry.values = logEntry.values.map(entry => {
-        return [JSON.stringify(entry.ts * 1000 * 1000), entry.line]
-      })
-      delete logEntry.entries
-      delete logEntry.labels
-      return logEntry
-    })
-    return batch
+    const streams = batch.streams.map(logStream => ({
+      stream: logStream.labels,
+      values: logStream.entries.map(entry => [JSON.stringify(entry.ts * 1000 * 1000), entry.line])
+    }))
+    return { streams }
   },
   prepareProtoBatch: batch => {
     batch.streams = batch.streams.map(logEntry => {


### PR DESCRIPTION
In the helpers.js file I see more cases of in-place editing of the batch objects. I'm not sure why it is done like this, but it does introduce a risk. If the goal is to prevent preparing a stream twice, I think it would be safer to do the preparation as soon as an event is added, not at the moment you want to send the data. 
