### PR TITLE
updated snappy to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "winston-transport": "^4.3.0"
   },
   "optionalDependencies": {
-    "snappy": "^6.1.1"
+    "snappy": "7.1.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
With snappy 6.1.1 i wasn't able to install on ubuntu 20, with nodejs 14 and npm 8. 
Also, snappy v7 is twice as fast as snappy v6. Read more [here](https://github.com/Brooooooklyn/snappy)
It has no breaking changes for this project. I have tested

