### PR TITLE
Add loki connection handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ LokiTransport() takes a Javascript object as an input. These are the options tha
 | `batching`         | If batching is not used, the logs are sent as they come   | true                   | true          |
 | `clearOnError`     | Discard any logs that result in an error during transport | true                   | false         |
 | `replaceTimestamp` | Replace any log timestamps with Date.now()                | true                   | false         |
-| `labels`           | custom labels, key-value pairs                            | { module: 'http' }     | null          |
-| `format`           | winston format (https://github.com/winstonjs/winston#formats) | simple()           | null          |
+| `labels`           | custom labels, key-value pairs                            | { module: 'http' }     | undefined     |
+| `format`           | winston format (https://github.com/winstonjs/winston#formats) | simple()           | undefined     |
 | `gracefulShutdown` | Enable/disable graceful shutdown (wait for any unsent batches) | false             | true          |
-| `timeout`          | timeout for requests to grafana loki in ms                | 30000                  | null          | 
-| `basicAuth`        | basic authentication credentials to access Loki over HTTP | username:password      | null          | 
+| `timeout`          | timeout for requests to grafana loki in ms                | 30000                  | undefined     | 
+| `basicAuth`        | basic authentication credentials to access Loki over HTTP | username:password      | undefined     | 
+| `onConnectionError`| Loki error connection handler                        | (err) => console.error(err) | undefined     | 
 
 ### Example
 With default formatting:

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,10 +9,10 @@ declare interface LokiTransportOptions extends TransportStream.TransportStreamOp
     batching?: boolean;
     labels?: object;
     clearOnError?: boolean,
-    replaceOnError?: boolean,
     replaceTimestamp?: boolean,
     gracefulShutdown?: boolean,
     timeout?: number,
+    onConnectionError?(error: unknown): void
 }
 
 declare class LokiTransport extends TransportStream {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class LokiTransport extends Transport {
       json: options.json,
       batching: options.batching !== false,
       clearOnError: options.clearOnError,
-      replaceOnError: options.replaceOnError,
+      onConnectionError: options.onConnectionError,
       replaceTimestamp: options.replaceTimestamp,
       gracefulShutdown: options.gracefulShutdown !== false,
       timeout: options.timeout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loki",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -201,6 +201,9 @@ class Batcher {
           .catch(err => {
             // Clear the batch on error if enabled
             this.options.clearOnError && this.clearBatch()
+
+            this.options.onConnectionError !== undefined && this.options.onConnectionError(err)
+
             reject(err)
           })
       }


### PR DESCRIPTION
¡Hi 👋🏻!

Recently found this repo and I realize that devs will never know about Loki connection errors (only a `console.error` in case that batching is `false` but this is not my case). 

Researching about this I saw that `winston-loki` does not provide any ways to recover or notify this, so this is my little contribution to the project.

Any feedback is welcome 😄 