### PR TITLE
Override loki transport label with log label when label with same name is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,13 +56,14 @@ class LokiTransport extends Transport {
 
     // build custom labels if provided
     let lokiLabels = { level: level }
-    lokiLabels = Object.assign(lokiLabels, labels)
 
     if (this.labels) {
       lokiLabels = Object.assign(lokiLabels, this.labels)
     } else {
       lokiLabels.job = label
     }
+
+    lokiLabels = Object.assign(lokiLabels, labels)
 
     // follow the format provided
     const line = this.useCustomFormat


### PR DESCRIPTION
Hi there,

I realize that transport labels provided in options during transport instantiation overrides custom ones provided in log when label name is same.

For example when you instantiate loki transport with default label `{ service: 'service-1' }` and then you want to log message with custom label e.q. service-2 `{ service: 'service-2' }` resulting log has value of service label equal to `service-1`, which IMHO is not desired behavior as one is not able to override log label after transport is instantiated.

Small fix in this PR solves this behavior and default labels from transport options can be override by custom label passed to log function.

Just changed order in which resulting labels gets merged.