### PR TITLE
Fixed bug in docker-compose.yaml promtail image

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     image: grafana/promtail:latest
     volumes:
       - /var/log:/var/log
-    command: -config.file=/etc/promtail/docker-config.yaml
+    command: -config.file=/etc/promtail/config.yml
     networks:
       - loki
 


### PR DESCRIPTION
The latest promtail image stores the config file at /etc/promtail/config.yml.
See instruction at layer 7 in:
https://hub.docker.com/layers/promtail/grafana/promtail/main/images/sha256-b0b83d56181a66a0f92109b80cde643b999ea9420fd92e11d235205ece9a74d3?context=explore