### PR TITLE
Fix sending of logs in invalid format when timestamp is not a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,11 +76,19 @@ class LokiTransport extends Transport {
     lokiLabels = Object.fromEntries(Object.entries(lokiLabels).map(([key, value]) => [key, value ? value.toString() : value]))
 
     // Construct the log to fit Grafana Loki's accepted format
+    let ts
+    if (timestamp) {
+      ts = new Date(timestamp)
+      ts = isNaN(ts) ? Date.now() : ts.valueOf()
+    } else {
+      ts = Date.now()
+    }
+
     const logEntry = {
       labels: lokiLabels,
       entries: [
         {
-          ts: timestamp || Date.now().valueOf(),
+          ts,
           line
         }
       ]

--- a/test/custom-labels-lines.test.js
+++ b/test/custom-labels-lines.test.js
@@ -1,28 +1,9 @@
 const { createLogger, format } = require('winston')
 const LokiTransport = require('winston-loki')
 
-// from: https://jestjs.io/docs/en/expect#expectextendmatchers
-expect.extend({
-  toBeWithinRange (received, floor, ceiling) {
-    const pass = received >= floor && received <= ceiling
-    if (pass) {
-      return {
-        message: () =>
-          `expected ${received} not to be within range ${floor} - ${ceiling}`,
-        pass: true
-      }
-    } else {
-      return {
-        message: () =>
-          `expected ${received} to be within range ${floor} - ${ceiling}`,
-        pass: false
-      }
-    }
-  }
-})
-
 describe('Integration tests', function () {
   it('Winston should accept LokiTransport', function () {
+    jest.useFakeTimers()
     const lokiTransport = new LokiTransport({
       host: 'http://localhost',
       level: 'debug',
@@ -46,7 +27,6 @@ describe('Integration tests', function () {
 
     const testMessage = 'testMessage'
     const testLabel = 'testLabel'
-    const now = Date.now()
     logger.debug({ message: testMessage, labels: { customLabel: testLabel } })
     expect(lokiTransport.batcher.batch.streams.length).toBe(1)
     expect(
@@ -55,7 +35,7 @@ describe('Integration tests', function () {
       labels: { level: 'debug', module: 'name', app: 'appname', customLabel: testLabel },
       entries: [{
         line: `[name] ${testMessage}`,
-        ts: expect.toBeWithinRange(now - 5, now + 5)
+        ts: Date.now()
       }]
     })
   })


### PR DESCRIPTION
This fixes the bug of no logs appearing in Loki when `winston-loki` is used with default `winston` format [timestamp](https://github.com/winstonjs/logform#timestamp).

The reason for that is that `timestamp` format is adding the `timestamp` field in the format of **ISO string** and `winston-loki` is just copying the value to Loki `ts` field while Loki is expecting `ts` to be **number**.

The fix is about trying to convert `timestamp` to **number** before assigning it to `ts` field. If conversion failed it would use the current time.

Also a change in the `custom-labels-lines.test.js` - preffer to use `jest.useFakeTimers()` instead of checking that time didn't elapse for too much while the test was executing. So now old and new tests working with time are following the same style and best practices.