### PR TITLE
feat: make agent configurable for underlying http(s) request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 import TransportStream from "winston-transport";
+import http from 'http';
+import https from 'https';
 
 declare interface LokiTransportOptions extends TransportStream.TransportStreamOptions{
     host: string;
@@ -12,6 +14,8 @@ declare interface LokiTransportOptions extends TransportStream.TransportStreamOp
     replaceTimestamp?: boolean,
     gracefulShutdown?: boolean,
     timeout?: number,
+    httpAgent?: http.Agent | boolean;
+    httpsAgent?: https.Agent | boolean;
     onConnectionError?(error: unknown): void
 }
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ class LokiTransport extends Transport {
       onConnectionError: options.onConnectionError,
       replaceTimestamp: options.replaceTimestamp !== false,
       gracefulShutdown: options.gracefulShutdown !== false,
-      timeout: options.timeout
+      timeout: options.timeout,
+      httpAgent: options.httpAgent,
+      httpsAgent: options.httpsAgent
     })
 
     this.useCustomFormat = options.format !== undefined

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -251,7 +251,7 @@ class Batcher {
         }
 
         // Send the data to Grafana Loki
-        req.post(this.url, this.contentType, this.options.headers, reqBody, this.options.timeout)
+        req.post(this.url, this.contentType, this.options.headers, reqBody, this.options.timeout, this.options.httpAgent, this.options.httpsAgent)
           .then(() => {
             // No need to clear the batch if batching is disabled
             logEntry === undefined && this.clearBatch()

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,7 +1,7 @@
 const http = require('http')
 const https = require('https')
 
-const post = async (lokiUrl, contentType, headers = {}, data = '', timeout) => {
+const post = async (lokiUrl, contentType, headers = {}, data = '', timeout, httpAgent, httpsAgent) => {
   // Construct a buffer from the data string to have deterministic data size
   const dataBuffer = Buffer.from(data, 'utf8')
 
@@ -14,6 +14,7 @@ const post = async (lokiUrl, contentType, headers = {}, data = '', timeout) => {
   return new Promise((resolve, reject) => {
     // Decide which http library to use based on the url
     const lib = lokiUrl.protocol === 'https:' ? https : http
+    const agent = lokiUrl.protocol === 'https:' ? httpsAgent : httpAgent
 
     // Construct the node request options
     const options = {
@@ -22,7 +23,8 @@ const post = async (lokiUrl, contentType, headers = {}, data = '', timeout) => {
       path: lokiUrl.pathname,
       method: 'POST',
       headers: Object.assign(defaultHeaders, headers),
-      timeout: timeout
+      timeout: timeout,
+      agent: agent
     }
 
     // Construct the request


### PR DESCRIPTION
We want to provide an http agent to the underlying requests to keep connections alive and therefore save sockets.