### PR TITLE
Add useWinstonMetaAsLabels option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ LokiTransport() takes a Javascript object as an input. These are the options tha
 | `timeout`          | timeout for requests to grafana loki in ms                | 30000                  | undefined     | 
 | `basicAuth`        | basic authentication credentials to access Loki over HTTP | username:password      | undefined     | 
 | `onConnectionError`| Loki error connection handler                        | (err) => console.error(err) | undefined     | 
+| `useWinstonMetaAsLabels` | Use Winston's "meta" (such as defaultMeta values) as Loki labels | true        | false         |
 
 ### Example
 With default formatting:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ LokiTransport() takes a Javascript object as an input. These are the options tha
 | `basicAuth`        | basic authentication credentials to access Loki over HTTP | username:password      | undefined     | 
 | `onConnectionError`| Loki error connection handler                        | (err) => console.error(err) | undefined     | 
 | `useWinstonMetaAsLabels` | Use Winston's "meta" (such as defaultMeta values) as Loki labels | true        | false         |
+| `ignoredMeta`      | When useWinstonMetaAsLabels is enabled, a list of meta values to ignore | ["error_description"]  | undefined |
 
 ### Example
 With default formatting:

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare interface LokiTransportOptions extends TransportStream.TransportStreamOp
     timeout?: number,
     httpAgent?: http.Agent | boolean;
     httpsAgent?: https.Agent | boolean;
+    useWinstonMetaAsLabels?: boolean;
     onConnectionError?(error: unknown): void
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare interface LokiTransportOptions extends TransportStream.TransportStreamOp
     httpAgent?: http.Agent | boolean;
     httpsAgent?: https.Agent | boolean;
     useWinstonMetaAsLabels?: boolean;
+    ignoredMeta?: Array<string>;
     onConnectionError?(error: unknown): void
 }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ class LokiTransport extends Transport {
 
     this.useCustomFormat = options.format !== undefined
     this.labels = options.labels
+    this.useWinstonMetaAsLabels = options.useWinstonMetaAsLabels
   }
 
   /**
@@ -60,10 +61,14 @@ class LokiTransport extends Transport {
     // build custom labels if provided
     let lokiLabels = { level: level }
 
-    if (this.labels) {
-      lokiLabels = Object.assign(lokiLabels, this.labels)
+    if (this.useWinstonMetaAsLabels) {
+      lokiLabels = Object.assign(lokiLabels, rest)
     } else {
-      lokiLabels.job = label
+      if (this.labels) {
+        lokiLabels = Object.assign(lokiLabels, this.labels)
+      } else {
+        lokiLabels.job = label
+      }
     }
 
     lokiLabels = Object.assign(lokiLabels, labels)

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class LokiTransport extends Transport {
     this.useCustomFormat = options.format !== undefined
     this.labels = options.labels
     this.useWinstonMetaAsLabels = options.useWinstonMetaAsLabels
+    this.ignoredMeta = options.ignoredMeta || []
   }
 
   /**
@@ -62,13 +63,15 @@ class LokiTransport extends Transport {
     let lokiLabels = { level: level }
 
     if (this.useWinstonMetaAsLabels) {
-      lokiLabels = Object.assign(lokiLabels, rest)
-    } else {
-      if (this.labels) {
-        lokiLabels = Object.assign(lokiLabels, this.labels)
-      } else {
-        lokiLabels.job = label
+      // deleting the keys (labels) that we want to ignore from Winston's meta
+      for (const [key, _] of Object.entries(rest)) {
+        if (this.ignoredMeta.includes(key)) delete rest[key]
       }
+      lokiLabels = Object.assign(lokiLabels, rest)
+    } else if (this.labels) {
+      lokiLabels = Object.assign(lokiLabels, this.labels)
+    } else {
+      lokiLabels.job = label
     }
 
     lokiLabels = Object.assign(lokiLabels, labels)


### PR DESCRIPTION
When enabled, this option pushes the "rest" of Winston's log info to Loki labels. 

This is useful to pass dynamic labels to Loki from the Winston log method directly, for example APIs HTTP methods or status codes.

This PR seems to contradict PR #103 that is still open, but since then, Grafana Loki devs are using dynamic labels in [their docs](https://grafana.com/docs/loki/latest/get-started/labels) for storing status codes or HTTP methods so it seems fair to use Winston's metadata to pass to Loki's labels, as long as they're not totally dynamic (e.g. different IDs for every log).

This option is disabled by default and overrides the "labels" option, because imo the fixed labels should be defined in Winston directly with the "defaultMeta" option when initializing a new Logger, but other ways might be better.

I named the option useWinstonMetaAsLabels because Winston considers anything other than "level" and "message" to be "meta" in their docs, though it could be shorter.

It should probably be paired with some sort of whitelist/blacklist to be able to only use some Winston meta as Loki labels, but I'm not sure which is best to implement.