### PR TITLE
Include Grafana Cloud Example; Support passing username/password via URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ LokiTransport() takes a Javascript object as an input. These are the options tha
 | `useWinstonMetaAsLabels` | Use Winston's "meta" (such as defaultMeta values) as Loki labels | true        | false         |
 | `ignoredMeta`      | When useWinstonMetaAsLabels is enabled, a list of meta values to ignore | ["error_description"]  | undefined |
 
-### Example
+### Example (Running Loki Locally)
 With default formatting:
 ```js
 const { createLogger, transports } = require("winston");
@@ -57,6 +57,37 @@ logger.debug({ message: 'test', labels: { 'key': 'value' } })
 ```
 
 TODO: Add custom formatting example
+
+### Example (Grafana Cloud Loki)
+
+**Important**: this snippet requires the following values, here are the instructions for how you can find them.
+
+* `LOKI_HOST`: find this in your Grafana Cloud instance by checking Connections > Data Sources, find the right Loki connection, and copy its URL, which may look like `https://logs-prod-006.grafana.net`
+* `USER_ID`: the user number in the same data source definition, it will be a multi-digit number like `372040`
+* `GRAFANA_CLOUD_TOKEN`: In Grafana Cloud, search for Cloud Access Policies. Create a new Cloud Access Policy, ensuring its scopes include `logs:write`.  Generate a token for this cloud access policy, and use this value here.
+
+```js
+const { createLogger, transports } = require("winston");
+const LokiTransport = require("winston-loki");
+const options = {
+  ...,
+  transports: [
+    new LokiTransport({
+        host: 'LOKI_HOST',
+        labels: { app: 'my-app' },
+        json: true,
+        basicAuth: 'USER_ID:GRAFANA_CLOUD_TOKEN',
+        format: winston.format.json(),
+        replaceTimestamp: true,
+        onConnectionError: (err) => console.error(err),
+    })
+  ]
+  ...
+};
+const logger = createLogger(options);
+logger.debug({ message: 'test', labels: { 'key': 'value' } })
+```
+
 
 ## Developing
 ### Requirements

--- a/src/batcher.js
+++ b/src/batcher.js
@@ -42,10 +42,13 @@ class Batcher {
     const URL = this.loadUrl()
     this.url = new URL(this.options.host + '/loki/api/v1/push')
 
+    const btoa = require('btoa')
     // Parse basic auth parameters if given
     if (options.basicAuth) {
-      const btoa = require('btoa')
       const basicAuth = 'Basic ' + btoa(options.basicAuth)
+      this.options.headers = Object.assign(this.options.headers, { Authorization: basicAuth })
+    } else if(this.url.username && this.url.password) {
+      const basicAuth = 'Basic ' + btoa(this.url.username + ':' + this.url.password)
       this.options.headers = Object.assign(this.options.headers, { Authorization: basicAuth })
     }
 


### PR DESCRIPTION
Fixes https://github.com/JaniAnttonen/winston-loki/issues/108

Partially addresses docs mentioned in https://github.com/JaniAnttonen/winston-loki/issues/140

This PR addresses two problems:

* When users pass HTTP basic auth via the URL (as in: `https://foo:bar@host`) the request library does not respect this and pass it along.  This is causing a lot of people to do work-arounds and get confused
* The library's examples show how to run Loki yourself but don't cover in the examples the common case of using Grafana Cloud, and how to get the tokens necessary to make that connection.

Note that users can now _either_ use `basicAuth` in options, or can specify the username/password in the URL.  It is apparent from the issues & forum postings that people are doing both, so it makes sense to support both.

The issue this PR fixes is also discussed [here](https://community.grafana.com/t/nodejs-logging-using-winston/76990) and has been viewed over 7,000 times as of this writing.

Thank you for putting together this winston-loki transport!  It's really nice and a lot of people are benefitting from it.  I hope this helps clear up confusions for some people without touching what people already rely on.