### PR TITLE
Add structured metadata to logEntry

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,8 @@ class LokiTransport extends Transport {
       entries: [
         {
           ts,
-          line
+          line,
+          rest
         }
       ]
     }

--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -16,7 +16,7 @@ module.exports = {
   prepareJSONBatch: batch => {
     const streams = batch.streams.map(logStream => ({
       stream: logStream.labels,
-      values: logStream.entries.map(entry => [JSON.stringify(entry.ts * 1000 * 1000), entry.line])
+      values: logStream.entries.map(entry => [JSON.stringify(entry.ts * 1000 * 1000), entry.line, entry.rest])
     }))
     return { streams }
   },


### PR DESCRIPTION
Now all rest data end up written as labels. As per loki json push protocol for loki, structured metadata is accepted on position 2 of "values" array. This PR suggest add "rest" object to log entry and in helper.js to pick it.