### PR TITLE
Adding the ability to merge default labels with meta labels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare interface LokiTransportOptions extends TransportStream.TransportStreamOp
     httpsAgent?: https.Agent | boolean;
     useWinstonMetaAsLabels?: boolean;
     ignoredMeta?: Array<string>;
+    metaToUseAsLabels?: Array<string>;
     onConnectionError?(error: unknown): void
 }
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class LokiTransport extends Transport {
     this.useCustomFormat = options.format !== undefined
     this.labels = options.labels
     this.useWinstonMetaAsLabels = options.useWinstonMetaAsLabels
+    this.metaToUseAsLabels = options.metaToUseAsLabels || []
     this.ignoredMeta = options.ignoredMeta || []
   }
 
@@ -64,10 +65,14 @@ class LokiTransport extends Transport {
 
     if (this.useWinstonMetaAsLabels) {
       // deleting the keys (labels) that we want to ignore from Winston's meta
-      for (const [key, _] of Object.entries(rest)) {
-        if (this.ignoredMeta.includes(key)) delete rest[key]
+      lokiLabels = {
+        ...lokiLabels,
+        ...(Object.fromEntries(this.metaToUseAsLabels.map(e => [e, rest[e]]))),
+        ...(this.labels ? this.labels : {})
       }
-      lokiLabels = Object.assign(lokiLabels, rest)
+      for (const [key, _] of Object.entries(rest)) {
+        if (this.ignoredMeta.includes(key) || this.metaToUseAsLabels.includes(key)) delete rest[key]
+      }
     } else if (this.labels) {
       lokiLabels = Object.assign(lokiLabels, this.labels)
     } else {
@@ -79,9 +84,7 @@ class LokiTransport extends Transport {
     // follow the format provided
     const line = this.useCustomFormat
       ? info[MESSAGE]
-      : `${message} ${
-      rest && Object.keys(rest).length > 0 ? JSON.stringify(rest) : ''
-    }`
+      : [message, rest && Object.keys(rest).length ? JSON.stringify(rest) : undefined].filter(Boolean).join(' ')
 
     // Make sure all label values are strings
     lokiLabels = Object.fromEntries(Object.entries(lokiLabels).map(([key, value]) => [key, value ? value.toString() : value]))
@@ -127,7 +130,7 @@ class LokiTransport extends Transport {
    * calls preceding the flush() call.
    */
   async flush () {
-    return await this.batcher.waitFlushed();
+    return await this.batcher.waitFlushed()
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winston-loki",
-  "version": "6.0.7",
+  "version": "6.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winston-loki",
-      "version": "6.0.7",
+      "version": "6.1.3",
       "license": "MIT",
       "dependencies": {
         "async-exit-hook": "2.0.1",
@@ -26,6 +26,7 @@
         "eslint-plugin-promise": "^4.0.1",
         "eslint-plugin-standard": "^4.0.0",
         "jest": "^27.4.7",
+        "node-fetch": "^2.7.0",
         "standard": "^16.0.4",
         "winston": "^3.5.1"
       },
@@ -7418,6 +7419,52 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8276,22 +8323,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^27.4.7",
+    "node-fetch": "^2.7.0",
     "standard": "^16.0.4",
     "winston": "^3.5.1"
   }

--- a/test/extra-meta-labels-as-loki-labels.test.js
+++ b/test/extra-meta-labels-as-loki-labels.test.js
@@ -1,0 +1,47 @@
+const fetch = require('node-fetch')
+const { createLogger } = require('winston')
+const LokiTransport = require('../index.js')
+const fixtures = require('./fixtures.json')
+
+
+class LokiClient {
+  static async getLogs (query, lokiHost) {
+    const url = new URL('loki/api/v1/query_range', lokiHost)
+    url.searchParams.append('query', query)
+    url.searchParams.append('limit', '10')
+
+    // eslint-disable-next-line no-undef
+    return fetch(url, {
+    }).then((response) => response.json())
+  }
+}
+describe('Loki Meta tests', function () {
+  it('Winston will append meta attributes to loki labels', async function () {
+    const options = {
+      transports: [new LokiTransport({
+        ...fixtures.options_labels,
+        host: process.env.LOKI_HOST,
+        ignoredMeta: ['level'],
+        metaToUseAsLabels: ['extraMeta']
+      })]
+    }
+    const logeMessage = 'testing the application'
+
+    // Create logger and add extra meta value
+    const logger = createLogger(options)
+    logger.info(logeMessage, { extraMeta: 'testValue' })
+
+    // Verify logger creation and meta value
+    expect(logger.constructor.name).toBe('DerivedLogger')
+    expect(logger._readableState.pipesCount).toBe(1)
+
+    const result = await LokiClient.getLogs('{extraMeta="testValue"}', process.env.LOKI_HOST)
+    expect(result.status).toBe('success')
+    expect(result.data.result.length).toBe(1)
+
+    const log = result.data.result[0]
+    expect(log.stream.extraMeta).toBe('testValue') // the value added rom the meta object
+    expect(log.stream.testingLabel).toBe('testingLabelValue') // the original label value
+    expect(log.values[0][1]).toBe(logeMessage) // the message
+  })
+})

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1,5 +1,8 @@
 {
   "options_json": { "host": "http://localhost", "interval": 0.1, "json": true },
+  "options_labels": { "host": "http://localhost", "interval": 0.1, "json": true,
+    "useWinstonMetaAsLabels": true,
+    "labels": { "testingLabel": "testingLabelValue" } },
   "options_no_batching": { "host": "http://localhost", "batching": false },
   "options_protobuf": {
     "host": "http://localhost",


### PR DESCRIPTION
**Features :**

- I added a new attribute to allow merging initial static labels put on definition of the transport, with meta attributes passed on the log call 

```
new LokiTransport({
 (...)
	useWinstonMetaAsLabels: true,
    ignoredMeta: ["level"],
    metaToUseAsLabels: ["newLabel"],
	labels: {
		initialLabel: "initialValue"
	}
(...)
})
// usage

logger.info("message", {newLabel: 'value'})

// loki result
message:  "message"
labels: {
	initialLabel: "initialValue",
	newLabel: 'value'	
}

```

The use of `ignoredMeta` and `useWinstonMetaAsLabels` is necessary to not get and extra level in the labels and a jsonified version in the message

- Added a test case for this, it will need a running instance of Loki to function properly
