### PR TITLE
fix(json): stringify meta values sent as structured metadata

### DIFF
--- a/src/proto/helpers.js
+++ b/src/proto/helpers.js
@@ -1,3 +1,12 @@
+// Loki's push API only accepts string values in structured metadata
+const toStringValues = rest =>
+  Object.fromEntries(
+    Object.entries(rest ?? {}).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? value : JSON.stringify(value)
+    ])
+  )
+
 module.exports = {
   createProtoTimestamps: logEntry => {
     if (logEntry && logEntry.entries && logEntry.entries.length > 0) {
@@ -18,7 +27,7 @@ module.exports = {
       stream: logStream.labels,
       // Convert milliseconds to nanoseconds in string space, as the
       // multiplied value exceeds Number.MAX_SAFE_INTEGER
-      values: logStream.entries.map(entry => [Math.floor(entry.ts) + '000000', entry.line, entry.rest])
+      values: logStream.entries.map(entry => [Math.floor(entry.ts) + '000000', entry.line, toStringValues(entry.rest)])
     }))
     return { streams }
   },

--- a/test/proto-helpers.test.js
+++ b/test/proto-helpers.test.js
@@ -1,0 +1,45 @@
+const { prepareJSONBatch } = require('../src/proto/helpers')
+
+describe('prepareJSONBatch', function () {
+  function batchWithRest (rest) {
+    return {
+      streams: [
+        {
+          labels: { level: 'info' },
+          entries: [{ ts: 1700000000000, line: 'msg', rest }]
+        }
+      ]
+    }
+  }
+
+  it('Should keep string meta values as they are', function () {
+    const { streams } = prepareJSONBatch(batchWithRest({ app: 'repro' }))
+    expect(streams[0].values[0]).toEqual([
+      '1700000000000000000',
+      'msg',
+      { app: 'repro' }
+    ])
+  })
+
+  it('Should convert non-string meta values to strings for structured metadata', function () {
+    const { streams } = prepareJSONBatch(
+      batchWithRest({
+        count: 5,
+        flag: true,
+        nested: { a: 1 },
+        list: [1, 'two']
+      })
+    )
+    expect(streams[0].values[0][2]).toEqual({
+      count: '5',
+      flag: 'true',
+      nested: '{"a":1}',
+      list: '[1,"two"]'
+    })
+  })
+
+  it('Should handle missing meta', function () {
+    const { streams } = prepareJSONBatch(batchWithRest(undefined))
+    expect(streams[0].values[0][2]).toEqual({})
+  })
+})


### PR DESCRIPTION
Loki's push API accepts only string values in structured metadata, so a single non-string meta value (e.g. `logger.info('msg', { count: 5 })`) made Loki reject the entire batch with HTTP 400, losing every log line in it. Convert values in prepareJSONBatch: strings pass through, everything else is JSON.stringify'd, keeping numbers and booleans readable (`5`, `true`) and nested objects as JSON (`{"a":1}`).

Fixes #192